### PR TITLE
Fix navigation after finalizing record trees

### DIFF
--- a/src/app/routes/records/route.tsx
+++ b/src/app/routes/records/route.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import { createContext } from 'react';
+import { useCallback } from 'react';
 import {
 	createFileRoute,
 	Link,
@@ -12,9 +11,6 @@ import { ListRecordsInputSchema } from '@/server/api/routers/types';
 import { RecordLink } from './-components/record-link';
 import { RecordsGrid } from './-components/records-grid';
 import { RadioCards, RadioCardsItem } from '@/components/radio-cards';
-
-// Create context for sharing data between parent and child routes
-export const NextRecordIdContext = createContext<number | undefined>(undefined);
 
 export const Route = createFileRoute('/records')({
 	validateSearch: ListRecordsInputSchema,
@@ -45,28 +41,8 @@ function RouteComponent() {
 		return recordIdMatch?.params?.recordId ? Number(recordIdMatch.params.recordId) : null;
 	}, [matches]);
 
-	// Calculate the next record ID whenever the selection changes
+	// Calculate the currently selected record ID
 	const currentRecordId = getSelectedRecordId();
-
-	// Update the next record ID whenever the selection or list changes
-	const nextRecordId = useMemo(() => {
-		// If the list is empty, there's no next record
-		if (!recordsList || recordsList.ids.length === 0) return undefined;
-
-		// If no record is currently selected, there's no concept of 'next'
-		if (!currentRecordId) return undefined;
-
-		const currentIndex = recordsList.ids.findIndex((record) => record.id === currentRecordId);
-
-		// If the current record isn't in the list, default to the first record in the list
-		if (currentIndex === -1) {
-			return recordsList.ids[0]?.id;
-		}
-
-		// Otherwise, find the next record, wrapping around to the beginning if necessary
-		const nextIndex = currentIndex + 1 < recordsList.ids.length ? currentIndex + 1 : 0;
-		return recordsList.ids[nextIndex]?.id;
-	}, [currentRecordId, recordsList]);
 
 	const handleValueChange = useCallback(
 		(value: string) => {
@@ -80,39 +56,36 @@ function RouteComponent() {
 	);
 
 	return (
-		<NextRecordIdContext.Provider value={nextRecordId}>
-			<main className={`flex basis-full overflow-hidden ${!isRecordSelected ? 'p-3' : ''}`}>
-				{isRecordSelected && recordsList ? (
-					<>
-						<div className="flex min-w-60 shrink grow-0 basis-72 flex-col gap-2 overflow-hidden border-r border-border py-3">
-							<header className="flex items-center justify-between px-3">
-								<h2 className="text-lg font-medium">
-									Records{' '}
-									<span className="text-sm text-c-secondary">({recordsList.ids.length})</span>
-								</h2>
-								<Link to="/records" search={true} className="text-sm">
-									Index
-								</Link>
-							</header>
-							<RadioCards
-								size="xs"
-								value={currentRecordId?.toString()}
-								onValueChange={handleValueChange}
-								className="flex flex-col gap-1 overflow-y-auto px-3"
-							>
-								{recordsList.ids.map(({ id }) => (
-									<RadioCardsItem key={id} value={id.toString()}>
-										<RecordLink id={id} className="w-full overflow-hidden" />
-									</RadioCardsItem>
-								))}
-							</RadioCards>
-						</div>
-						<Outlet />
-					</>
-				) : (
-					<RecordsGrid />
-				)}
-			</main>
-		</NextRecordIdContext.Provider>
+		<main className={`flex basis-full overflow-hidden ${!isRecordSelected ? 'p-3' : ''}`}>
+			{isRecordSelected && recordsList ? (
+				<>
+					<div className="flex min-w-60 shrink grow-0 basis-72 flex-col gap-2 overflow-hidden border-r border-border py-3">
+						<header className="flex items-center justify-between px-3">
+							<h2 className="text-lg font-medium">
+								Records <span className="text-sm text-c-secondary">({recordsList.ids.length})</span>
+							</h2>
+							<Link to="/records" search={true} className="text-sm">
+								Index
+							</Link>
+						</header>
+						<RadioCards
+							size="xs"
+							value={currentRecordId?.toString()}
+							onValueChange={handleValueChange}
+							className="flex flex-col gap-1 overflow-y-auto px-3"
+						>
+							{recordsList.ids.map(({ id }) => (
+								<RadioCardsItem key={id} value={id.toString()}>
+									<RecordLink id={id} className="w-full overflow-hidden" />
+								</RadioCardsItem>
+							))}
+						</RadioCards>
+					</div>
+					<Outlet />
+				</>
+			) : (
+				<RecordsGrid />
+			)}
+		</main>
 	);
 }


### PR DESCRIPTION
## Summary
- finalize handlers deduplicate IDs and include the current record
- drop the NextRecordIdContext provider
- always include the current record in the flattened tree

## Testing
- `npm run lint` *(fails: cannot find ESLint dependencies)*