### PR TITLE
Implement useRecordUpload and toast handling

### DIFF
--- a/src/app/components/media-upload.tsx
+++ b/src/app/components/media-upload.tsx
@@ -4,6 +4,7 @@ import { UploadIcon } from 'lucide-react';
 import { z } from 'zod';
 import { Spinner } from './spinner';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 
 const mediaFileSchema = z
@@ -43,9 +44,10 @@ export const MediaUpload = forwardRef<HTMLDivElement, MediaUploadProps>(
 
 				try {
 					const validatedFile = validationSchema.parse(file);
-					setStatusMessage(`Uploading ${validatedFile.name}...`);
-					await onUpload(validatedFile);
-					setStatusMessage('Upload successful!');
+                                setStatusMessage(`Uploading ${validatedFile.name}...`);
+                                        await onUpload(validatedFile);
+                                        setStatusMessage('Upload successful!');
+                                        toast.success('Upload successful');
 					// Optionally reset after a delay
 					// setTimeout(() => setStatusMessage('Drag file here, paste, or click to upload'), 2000);
 				} catch (err) {
@@ -55,9 +57,9 @@ export const MediaUpload = forwardRef<HTMLDivElement, MediaUploadProps>(
 					} else if (err instanceof Error) {
 						errorMessage = `Upload failed: ${err.message}`;
 					}
-					setError(errorMessage);
-					setStatusMessage('Drag file here, paste, or click to upload');
-					console.error('File validation or upload error:', err);
+                                        setError(errorMessage);
+                                        setStatusMessage('Drag file here, paste, or click to upload');
+                                        toast.error(errorMessage);
 				} finally {
 					// Reset file input to allow uploading the same file again
 					if (fileInputRef.current) {

--- a/src/app/lib/hooks/use-record-upload.ts
+++ b/src/app/lib/hooks/use-record-upload.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { useCreateMedia } from './use-records';
+import { readFileAsBase64 } from '../read-file';
+import type { DbId } from '@/server/api/routers/common';
+
+export function useRecordUpload(recordId: DbId) {
+  const createMediaMutation = useCreateMedia(recordId);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const upload = useCallback(
+    async (file: File) => {
+      setError(null);
+      setSuccess(false);
+      try {
+        const fileData = await readFileAsBase64(file);
+        await createMediaMutation.mutateAsync({
+          recordId,
+          fileData,
+          fileName: file.name,
+          fileType: file.type,
+        });
+        setSuccess(true);
+        toast.success('Media uploaded');
+        return { success: true } as const;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Upload failed';
+        setError(message);
+        toast.error(message);
+        return { success: false, error: message } as const;
+      }
+    },
+    [recordId, createMediaMutation]
+  );
+
+  return {
+    upload,
+    isUploading: createMediaMutation.isLoading,
+    success,
+    error,
+  } as const;
+}

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -44,12 +44,11 @@ import {
 import MediaGrid from '@/components/media-grid';
 import { MediaUpload } from '@/components/media-upload';
 import {
-	useCreateMedia,
-	useDeleteMedia,
-	useRecord,
-	useUpsertRecord,
+        useDeleteMedia,
+        useRecord,
+        useUpsertRecord,
 } from '@/lib/hooks/use-records';
-import { readFileAsBase64 } from '@/lib/read-file';
+import { useRecordUpload } from '@/lib/hooks/use-record-upload';
 import { cn } from '@/lib/utils';
 
 interface RecordFormProps extends React.HTMLAttributes<HTMLFormElement> {
@@ -115,32 +114,9 @@ export function RecordForm({
 	const mediaCaptionRef = useRef<HTMLTextAreaElement>(null);
 	const mediaUploadRef = useRef<HTMLDivElement>(null);
 
-	const updateMutation = useUpsertRecord();
-	const createMediaMutation = useCreateMedia(recordId);
-	const deleteMediaMutation = useDeleteMedia();
-
-	const handleUpload = useCallback(
-		async (file: File) => {
-			console.log('File selected:', file.name, file.type, file.size);
-			try {
-				const fileData = await readFileAsBase64(file);
-				await createMediaMutation.mutateAsync({
-					recordId: recordId,
-					fileData: fileData,
-					fileName: file.name,
-					fileType: file.type,
-				});
-			} catch (error) {
-				console.error('Failed to read or upload file:', error);
-				if (error instanceof Error) {
-					throw new Error(`Upload processing failed: ${error.message}`);
-				} else {
-					throw new Error('An unknown error occurred during file processing or upload.');
-				}
-			}
-		},
-		[recordId, createMediaMutation, readFileAsBase64]
-	);
+        const updateMutation = useUpsertRecord();
+        const deleteMediaMutation = useDeleteMedia();
+        const { upload: handleUpload } = useRecordUpload(recordId);
 
 	const form = useForm({
 		defaultValues: record ?? defaultData,


### PR DESCRIPTION
## Summary
- add a new `useRecordUpload` hook to centralize media upload logic
- use the hook in the records form component
- show toast messages in `MediaUpload` instead of console logs

## Testing
- `pnpm lint` *(fails: fetch error installing pnpm)*