### PR TITLE
Refactor relationship selector components

### DIFF
--- a/src/app/lib/hooks/use-record-search.ts
+++ b/src/app/lib/hooks/use-record-search.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useDebounce } from './use-debounce';
+import { trpc } from '@/app/trpc';
+import { useUpsertRecord } from './use-records';
+
+export function useRecordSearch() {
+        const [query, setQuery] = useState('');
+        const debounced = useDebounce(query, 200);
+
+        const createRecordMutation = useUpsertRecord();
+
+        const { data = [], isFetching } = trpc.search.byTextQuery.useQuery(
+                { query: debounced, limit: 5 },
+                { enabled: debounced.length > 0 }
+        );
+
+        const createRecord = async () => {
+                const newRecord = await createRecordMutation.mutateAsync({
+                        type: 'artifact',
+                        title: query,
+                });
+                return newRecord;
+        };
+
+        return {
+                query,
+                setQuery,
+                results: data,
+                isFetching,
+                createRecord,
+                createRecordMutation,
+        };
+}

--- a/src/app/routes/records/-components/predicate-combobox.tsx
+++ b/src/app/routes/records/-components/predicate-combobox.tsx
@@ -1,0 +1,59 @@
+import type { PredicateSelect } from '@/db/schema';
+import type { RelationshipAction } from './record-lookup';
+import {
+        Command,
+        CommandGroup,
+        CommandInput,
+        CommandItem,
+        CommandList,
+        CommandSeparator,
+} from '@/components/ui/command';
+
+interface PredicateComboboxProps {
+        predicates: PredicateSelect[];
+        onPredicateSelect(id: number): void;
+        actions?: RelationshipAction[];
+        includeNonCanonical?: boolean;
+}
+
+export function PredicateCombobox({
+        predicates,
+        onPredicateSelect,
+        actions = [],
+        includeNonCanonical = false,
+}: PredicateComboboxProps) {
+        return (
+                <Command className="w-full">
+                        <CommandInput autoFocus placeholder="Select relation type…" />
+                        <CommandList>
+                                <CommandGroup heading="Predicates">
+                                        {predicates
+                                                .filter((p) => includeNonCanonical || p.canonical)
+                                                .map((p) => (
+                                                        <CommandItem
+                                                                className="flex gap-2 capitalize"
+                                                                key={p.id}
+                                                                onSelect={() => onPredicateSelect(p.id)}
+                                                        >
+                                                                <span className="font-medium">{p.name}</span>
+                                                                <span className="text-c-hint">{p.type}</span>
+                                                        </CommandItem>
+                                                ))}
+                                </CommandGroup>
+
+                                {actions.length > 0 && (
+                                        <>
+                                                <CommandSeparator />
+                                                <CommandGroup heading="Actions">
+                                                        {actions.map((a) => (
+                                                                <CommandItem key={a.key} onSelect={a.onSelect}>
+                                                                        {a.label}
+                                                                </CommandItem>
+                                                        ))}
+                                                </CommandGroup>
+                                        </>
+                                )}
+                        </CommandList>
+                </Command>
+        );
+}

--- a/src/app/routes/records/-components/record-search.tsx
+++ b/src/app/routes/records/-components/record-search.tsx
@@ -1,0 +1,54 @@
+import type { DbId } from '@/server/api/routers/common';
+import { PlusCircleIcon } from 'lucide-react';
+import { useRecordSearch } from '@/lib/hooks/use-record-search';
+import { SearchResultItem } from './search-result-item';
+import {
+        Command,
+        CommandGroup,
+        CommandInput,
+        CommandItem,
+        CommandList,
+        CommandLoading,
+        CommandSeparator,
+} from '@/components/ui/command';
+
+interface RecordSearchProps {
+        onSelect(id: DbId): void;
+}
+
+export function RecordSearch({ onSelect }: RecordSearchProps) {
+        const { query, setQuery, results, isFetching, createRecord } = useRecordSearch();
+
+        return (
+                <Command shouldFilter={false} loop className="w-full">
+                        <CommandInput autoFocus value={query} onValueChange={setQuery} placeholder="Find a record…" />
+                        <CommandList>
+                                <CommandGroup heading="Search results">
+                                        {isFetching && <CommandLoading>Loading results...</CommandLoading>}
+                                        {results.map((result) => (
+                                                <CommandItem
+                                                        key={result.id}
+                                                        value={`${result.title ?? 'Untitled'}--${result.id}`}
+                                                        onSelect={() => onSelect(result.id)}
+                                                >
+                                                        <SearchResultItem result={result} />
+                                                </CommandItem>
+                                        ))}
+                                        {!isFetching && results.length === 0 && <CommandItem disabled>No results</CommandItem>}
+                                </CommandGroup>
+                                <CommandSeparator alwaysRender />
+                                <CommandItem
+                                        disabled={query.length === 0 || isFetching}
+                                        key="create-record"
+                                        onSelect={async () => {
+                                                const newRecord = await createRecord();
+                                                onSelect(newRecord.id);
+                                        }}
+                                        className="px-3 py-2"
+                                >
+                                        <PlusCircleIcon /> Create New Record
+                                </CommandItem>
+                        </CommandList>
+                </Command>
+        );
+}


### PR DESCRIPTION
## Summary
- move `RecordSearch` and `PredicateCombobox` to their own files
- add `useRecordSearch` hook for debounced searching and record creation
- update `RelationshipSelector` to import new pieces

## Testing
- `prettier` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*