### PR TITLE
Refactor record form into modular components

### DIFF
--- a/src/app/routes/records/-components/ContentSection.tsx
+++ b/src/app/routes/records/-components/ContentSection.tsx
@@ -1,0 +1,73 @@
+import type { UseFormReturn } from '@tanstack/react-form';
+import { DynamicTextarea, Label, Separator } from '@/components';
+import type { RecordGet } from '@/server/api/routers/types';
+
+interface Props {
+    form: UseFormReturn<RecordGet>;
+}
+
+export const ContentSection = ({ form }: Props) => (
+    <>
+        <form.Field name="summary">
+            {(field) => (
+                <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="summary">Summary</Label>
+                    <DynamicTextarea
+                        id="summary"
+                        value={field.state.value ?? ''}
+                        placeholder="A brief summary of this record"
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault();
+                                form.handleSubmit();
+                            }
+                        }}
+                    />
+                </div>
+            )}
+        </form.Field>
+
+        <form.Field name="content">
+            {(field) => (
+                <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="content">Content</Label>
+                    <DynamicTextarea
+                        id="content"
+                        value={field.state.value ?? ''}
+                        placeholder="Main content"
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault();
+                                form.handleSubmit();
+                            }
+                        }}
+                    />
+                </div>
+            )}
+        </form.Field>
+
+        <Separator />
+
+        <form.Field name="notes">
+            {(field) => (
+                <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="notes">Notes</Label>
+                    <DynamicTextarea
+                        id="notes"
+                        value={field.state.value ?? ''}
+                        placeholder="Additional notes"
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault();
+                                form.handleSubmit();
+                            }
+                        }}
+                    />
+                </div>
+            )}
+        </form.Field>
+    </>
+);

--- a/src/app/routes/records/-components/MediaSection.tsx
+++ b/src/app/routes/records/-components/MediaSection.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useRef } from 'react';
+import type { UseFormReturn } from '@tanstack/react-form';
+import { DynamicTextarea, Label } from '@/components';
+import MediaGrid from '@/components/media-grid';
+import { MediaUpload } from '@/components/media-upload';
+import { useCreateMedia, useDeleteMedia } from '@/lib/hooks/use-records';
+import { readFileAsBase64 } from '@/lib/read-file';
+import type { RecordGet } from '@/server/api/routers/types';
+
+interface Props {
+    recordId: number;
+    form: UseFormReturn<RecordGet>;
+}
+
+export const MediaSection = ({ recordId, form }: Props) => {
+    const mediaCaptionRef = useRef<HTMLTextAreaElement>(null);
+    const mediaUploadRef = useRef<HTMLDivElement>(null);
+
+    const createMedia = useCreateMedia(recordId);
+    const deleteMedia = useDeleteMedia();
+
+    const handleUpload = useCallback(async (file: File) => {
+        const fileData = await readFileAsBase64(file);
+        await createMedia.mutateAsync({
+            recordId,
+            fileData,
+            fileName: file.name,
+            fileType: file.type,
+        });
+    }, [recordId, createMedia]);
+
+    return (
+        <form.Field name="media">
+            {(field) =>
+                field.state.value && field.state.value.length > 0 ? (
+                    <div className="flex flex-col gap-3">
+                        <MediaGrid
+                            media={field.state.value}
+                            onDelete={(media) => deleteMedia.mutate([media.id])}
+                        />
+                        <form.Field name="mediaCaption">
+                            {(captionField) => (
+                                <div className="flex flex-col gap-1">
+                                    <Label htmlFor="mediaCaption">Caption</Label>
+                                    <DynamicTextarea
+                                        ref={mediaCaptionRef}
+                                        id="mediaCaption"
+                                        value={captionField.state.value ?? ''}
+                                        placeholder="Media caption"
+                                        onChange={(e) => captionField.handleChange(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' && !e.shiftKey) {
+                                                e.preventDefault();
+                                                form.handleSubmit();
+                                            }
+                                        }}
+                                    />
+                                </div>
+                            )}
+                        </form.Field>
+                    </div>
+                ) : (
+                    <MediaUpload ref={mediaUploadRef} onUpload={handleUpload} />
+                )
+            }
+        </form.Field>
+    );
+};

--- a/src/app/routes/records/-components/MetadataSection.tsx
+++ b/src/app/routes/records/-components/MetadataSection.tsx
@@ -1,0 +1,20 @@
+import type { RecordGet } from '@/server/api/routers/types';
+import { MetadataList } from '@/components';
+
+export const MetadataSection = ({ record }: { record: RecordGet }) => {
+    return (
+        <div className="flex flex-col gap-3">
+            <h2>Record Metadata</h2>
+            <MetadataList
+                metadata={{
+                    ID: record.id,
+                    Slug: record.slug,
+                    Created: record.recordCreatedAt,
+                    Updated: record.recordUpdatedAt,
+                    'Content Created': record.contentCreatedAt,
+                    'Content Updated': record.contentUpdatedAt,
+                }}
+            />
+        </div>
+    );
+};

--- a/src/app/routes/records/-components/use-record-form.ts
+++ b/src/app/routes/records/-components/use-record-form.ts
@@ -1,0 +1,98 @@
+import { useCallback } from 'react';
+import { useForm, type UseFormReturn } from '@tanstack/react-form';
+import { RecordInsertSchema } from '@/server/db/schema';
+import type { RecordGet } from '@/server/api/routers/types';
+import { useCreateMedia, useDeleteMedia, useRecord, useUpsertRecord } from '@/lib/hooks/use-records';
+import { readFileAsBase64 } from '@/lib/read-file';
+
+const defaultData: RecordGet = {
+    id: 0,
+    slug: null,
+    type: 'artifact',
+    title: null,
+    sense: null,
+    abbreviation: null,
+    url: null,
+    avatarUrl: null,
+    summary: null,
+    content: null,
+    notes: null,
+    mediaCaption: null,
+    isCurated: false,
+    isPrivate: false,
+    rating: 0,
+    reminderAt: null,
+    sources: [],
+    media: [],
+    recordCreatedAt: new Date(),
+    recordUpdatedAt: new Date(),
+    contentCreatedAt: new Date(),
+    contentUpdatedAt: new Date(),
+} as const;
+
+export interface UseRecordFormReturn {
+    form: UseFormReturn<RecordGet>;
+    record: RecordGet | undefined;
+    isLoading: boolean;
+    isError: boolean;
+    handleUpload: (file: File) => Promise<void>;
+    deleteMedia: ReturnType<typeof useDeleteMedia>;
+}
+
+export const useRecordForm = (recordId: number): UseRecordFormReturn => {
+    const { data: record, isLoading, isError } = useRecord(recordId);
+    const updateMutation = useUpsertRecord();
+    const createMediaMutation = useCreateMedia(recordId);
+    const deleteMedia = useDeleteMedia();
+
+    const handleUpload = useCallback(async (file: File) => {
+        const fileData = await readFileAsBase64(file);
+        await createMediaMutation.mutateAsync({
+            recordId,
+            fileData,
+            fileName: file.name,
+            fileType: file.type,
+        });
+    }, [recordId, createMediaMutation]);
+
+    const form = useForm({
+        defaultValues: record ?? defaultData,
+        onSubmit: async ({ value }) => {
+            const {
+                title,
+                url,
+                avatarUrl,
+                abbreviation,
+                sense,
+                summary,
+                content,
+                notes,
+                mediaCaption,
+                ...rest
+            } = value;
+            await updateMutation.mutateAsync({
+                ...rest,
+                title: title || null,
+                url: url || null,
+                avatarUrl: avatarUrl || null,
+                abbreviation: abbreviation || null,
+                sense: sense || null,
+                summary: summary || null,
+                content: content || null,
+                notes: notes || null,
+                mediaCaption: mediaCaption || null,
+            });
+        },
+        validators: {
+            onSubmit: ({ value }) => {
+                const parsed = RecordInsertSchema.safeParse(value);
+                if (!parsed.success) {
+                    return parsed.error.flatten().fieldErrors;
+                }
+                return undefined;
+            },
+        },
+    });
+
+    return { form, record, isLoading, isError, handleUpload, deleteMedia };
+};


### PR DESCRIPTION
## Summary
- split the record form into MetadataSection, ContentSection and MediaSection
- add `useRecordForm` hook with form logic
- update `RecordForm` to use the new hook and components

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*