### PR TITLE
Refactor media upload handling

### DIFF
--- a/src/app/components/media-upload.tsx
+++ b/src/app/components/media-upload.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { forwardRef, useCallback, useRef, useState } from 'react';
 import { UploadIcon } from 'lucide-react';
+import { toast } from 'sonner';
 import { z } from 'zod';
 import { Spinner } from './spinner';
 import { Button } from '@/components/ui/button';
@@ -57,7 +58,7 @@ export const MediaUpload = forwardRef<HTMLDivElement, MediaUploadProps>(
 					}
 					setError(errorMessage);
 					setStatusMessage('Drag file here, paste, or click to upload');
-					console.error('File validation or upload error:', err);
+					toast.error(errorMessage);
 				} finally {
 					// Reset file input to allow uploading the same file again
 					if (fileInputRef.current) {

--- a/src/app/lib/hooks/use-record-upload.ts
+++ b/src/app/lib/hooks/use-record-upload.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import type { DbId } from '@/server/api/routers/common';
+import { readFileAsBase64 } from '../read-file';
+import { useCreateMedia } from './use-records';
+
+export interface UseRecordUploadResult {
+	uploadFile: (file: File) => Promise<void>;
+	isUploading: boolean;
+	isSuccess: boolean;
+	error: Error | null;
+}
+
+export function useRecordUpload(recordId: DbId): UseRecordUploadResult {
+	const createMediaMutation = useCreateMedia(recordId);
+	const [isSuccess, setIsSuccess] = useState(false);
+	const [error, setError] = useState<Error | null>(null);
+	const [isUploading, setIsUploading] = useState(false);
+
+	const uploadFile = useCallback(
+		async (file: File) => {
+			setIsSuccess(false);
+			setError(null);
+			setIsUploading(true);
+			try {
+				const fileData = await readFileAsBase64(file);
+				await createMediaMutation.mutateAsync({
+					recordId,
+					fileData,
+					fileName: file.name,
+					fileType: file.type,
+				});
+				setIsSuccess(true);
+				toast.success('Media uploaded');
+			} catch (err) {
+				const message = err instanceof Error ? err.message : 'Unknown error during upload';
+				setError(err instanceof Error ? err : new Error(message));
+				toast.error(`Upload failed: ${message}`);
+				throw err;
+			} finally {
+				setIsUploading(false);
+			}
+		},
+		[recordId, createMediaMutation]
+	);
+
+	return { uploadFile, isUploading, isSuccess, error };
+}

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -43,13 +43,8 @@ import {
 } from '@/components';
 import MediaGrid from '@/components/media-grid';
 import { MediaUpload } from '@/components/media-upload';
-import {
-	useCreateMedia,
-	useDeleteMedia,
-	useRecord,
-	useUpsertRecord,
-} from '@/lib/hooks/use-records';
-import { readFileAsBase64 } from '@/lib/read-file';
+import { useRecordUpload } from '@/lib/hooks/use-record-upload';
+import { useDeleteMedia, useRecord, useUpsertRecord } from '@/lib/hooks/use-records';
 import { cn } from '@/lib/utils';
 
 interface RecordFormProps extends React.HTMLAttributes<HTMLFormElement> {
@@ -116,31 +111,8 @@ export function RecordForm({
 	const mediaUploadRef = useRef<HTMLDivElement>(null);
 
 	const updateMutation = useUpsertRecord();
-	const createMediaMutation = useCreateMedia(recordId);
 	const deleteMediaMutation = useDeleteMedia();
-
-	const handleUpload = useCallback(
-		async (file: File) => {
-			console.log('File selected:', file.name, file.type, file.size);
-			try {
-				const fileData = await readFileAsBase64(file);
-				await createMediaMutation.mutateAsync({
-					recordId: recordId,
-					fileData: fileData,
-					fileName: file.name,
-					fileType: file.type,
-				});
-			} catch (error) {
-				console.error('Failed to read or upload file:', error);
-				if (error instanceof Error) {
-					throw new Error(`Upload processing failed: ${error.message}`);
-				} else {
-					throw new Error('An unknown error occurred during file processing or upload.');
-				}
-			}
-		},
-		[recordId, createMediaMutation, readFileAsBase64]
-	);
+	const { uploadFile } = useRecordUpload(recordId);
 
 	const form = useForm({
 		defaultValues: record ?? defaultData,
@@ -546,7 +518,7 @@ export function RecordForm({
 								</form.Field>
 							</div>
 						) : (
-							<MediaUpload ref={mediaUploadRef} onUpload={handleUpload} />
+							<MediaUpload ref={mediaUploadRef} onUpload={uploadFile} />
 						)
 					}
 				</form.Field>


### PR DESCRIPTION
## Summary
- extract record upload logic to `useRecordUpload`
- show toast messages for media upload errors
- use new hook inside `RecordForm`

## Testing
- `pnpm lint`