### PR TITLE
Add lazy loading for images and videos

### DIFF
--- a/src/app/components/lazy-video.tsx
+++ b/src/app/components/lazy-video.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface LazyVideoProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
+	/** Controls browser lazy loading hint */
+	loading?: 'lazy' | 'eager';
+}
+
+export const LazyVideo = React.forwardRef<HTMLVideoElement, LazyVideoProps>(function LazyVideo(
+	{ loading = 'lazy', preload = 'none', ...props },
+	ref
+) {
+	return React.createElement('video', {
+		ref,
+		preload,
+		loading,
+		...props,
+	});
+});
+
+export default LazyVideo;

--- a/src/app/components/media-grid.tsx
+++ b/src/app/components/media-grid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Trash2Icon } from 'lucide-react';
 import type { MediaSelect } from '@/server/db/schema/media';
+import { LazyVideo } from './lazy-video';
 import { Button } from './ui/button';
 
 interface MediaGridProps {
@@ -35,7 +36,7 @@ const MediaGrid: React.FC<MediaGridProps> = ({ media, className = '', onDelete }
 
 					{/* Render video or image based on media type */}
 					{item.type === 'video' ? (
-						<video
+						<LazyVideo
 							src={item.url}
 							className="h-full w-full object-cover"
 							controls
@@ -43,13 +44,14 @@ const MediaGrid: React.FC<MediaGridProps> = ({ media, className = '', onDelete }
 							loop
 							autoPlay
 							playsInline
-							preload="metadata"
 						/>
 					) : (
 						<img
 							src={item.url}
 							alt={item.altText || `Media ${index + 1}`}
 							className="h-full w-full object-cover"
+							loading="lazy"
+							decoding="async"
 						/>
 					)}
 

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
+import { LazyVideo } from '@/components/lazy-video';
 import { Spinner } from '@/components/spinner';
 import { useRecordList } from '@/lib/hooks/use-records';
 
@@ -39,20 +40,21 @@ function Home() {
 							{/* Gradient from bottom 50% with semi-transparent black */}
 							<div className="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 z-10 bg-gradient-to-t from-black/80 to-transparent opacity-75" />
 							{item.type === 'video' ? (
-								<video
+								<LazyVideo
 									src={item.url}
 									className="absolute inset-0 size-full object-cover"
 									muted
 									loop
 									playsInline
 									autoPlay
-									preload="metadata"
 								/>
 							) : (
 								<img
 									src={item.url}
 									alt={item.altText || record.title || `Media for record ${record.id}`}
 									className="absolute inset-0 size-full object-cover"
+									loading="lazy"
+									decoding="async"
 								/>
 							)}
 							{/* White text with semi-transparent black shadow */}

--- a/src/app/routes/records/-components/record-link.tsx
+++ b/src/app/routes/records/-components/record-link.tsx
@@ -7,6 +7,7 @@ import { usePredicateMap, useRecordWithOutgoingLinks } from '@/app/lib/hooks/use
 import type { DbId } from '@/server/api/routers/common';
 import { recordTypeIcons } from './type-icons';
 import { IntegrationLogo } from '@/components/integration-logo';
+import { LazyVideo } from '@/components/lazy-video';
 import { Spinner } from '@/components/spinner';
 import {
 	DropdownMenu,
@@ -166,9 +167,11 @@ export const RecordLink = memo(({ id, className, linkOptions, actions }: RecordL
 							src={mediaItem.url}
 							alt={mediaItem.altText ?? mediaCaption ?? ''}
 							className="absolute inset-0 size-full object-cover"
+							loading="lazy"
+							decoding="async"
 						/>
 					) : (
-						<video src={mediaItem.url} className="absolute inset-0 object-cover" />
+						<LazyVideo src={mediaItem.url} className="absolute inset-0 object-cover" />
 					)}
 				</div>
 			)}

--- a/src/app/routes/records/-components/search-result-item.tsx
+++ b/src/app/routes/records/-components/search-result-item.tsx
@@ -1,6 +1,7 @@
 import type { SearchResult } from '@/server/api/routers/search';
 import { recordTypeIcons } from './type-icons';
 import { IntegrationLogo } from '@/components/integration-logo';
+import { LazyVideo } from '@/components/lazy-video';
 import type { MediaType } from '@/db/schema';
 import { toTitleCase } from '@/lib/formatting';
 import { usePredicateMap } from '@/lib/hooks/use-records';
@@ -73,9 +74,11 @@ export const SearchResultItem = ({ result }: { result: SearchResult }) => {
 							src={mediaItem.url}
 							alt={mediaItem.altText ?? mediaCaption ?? ''}
 							className="absolute inset-0 size-full object-cover"
+							loading="lazy"
+							decoding="async"
 						/>
 					) : (
-						<video src={mediaItem.url} className="absolute inset-0 object-cover" />
+						<LazyVideo src={mediaItem.url} className="absolute inset-0 object-cover" />
 					)}
 				</div>
 			)}


### PR DESCRIPTION
## Summary
- create `LazyVideo` component for consistent video lazy loading
- update media components to use `LazyVideo`
- add `loading="lazy"` and `decoding="async"` to `<img>` elements

## Testing
- `pnpm lint`
