### PR TITLE
Improve front-end performance

### DIFF
--- a/src/app/routes/-app-components/site-search.tsx
+++ b/src/app/routes/-app-components/site-search.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useDeferredValue, useEffect, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { SearchIcon } from 'lucide-react';
 import { trpc } from '@/app/trpc';
@@ -22,7 +22,8 @@ export const SiteSearch = () => {
 	const navigate = useNavigate();
 	const [inputValue, setInputValue] = useState('');
 	const [commandOpen, setCommandOpen] = useState(false);
-	const debouncedValue = useDebounce(inputValue, 300);
+	const deferredValue = useDeferredValue(inputValue);
+	const debouncedValue = useDebounce(deferredValue, 300);
 
 	const { data: textResults, isLoading: textResultsLoading } = trpc.search.byTextQuery.useQuery(
 		{

--- a/src/app/routes/records/-components/search-result-item.tsx
+++ b/src/app/routes/records/-components/search-result-item.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { SearchResult } from '@/server/api/routers/search';
 import { recordTypeIcons } from './type-icons';
 import { IntegrationLogo } from '@/components/integration-logo';
@@ -6,7 +7,11 @@ import type { MediaType } from '@/db/schema';
 import { toTitleCase } from '@/lib/formatting';
 import { usePredicateMap } from '@/lib/hooks/use-records';
 
-export const SearchResultItem = ({ result }: { result: SearchResult }) => {
+export const SearchResultItem = memo(function SearchResultItem({
+	result,
+}: {
+	result: SearchResult;
+}) {
 	const predicates = usePredicateMap();
 	const {
 		type,
@@ -93,4 +98,4 @@ export const SearchResultItem = ({ result }: { result: SearchResult }) => {
 			) : null}
 		</div>
 	);
-};
+});


### PR DESCRIPTION
## Summary
- remove unnecessary lazy loading from layout and records page
- debounce search with `useDeferredValue`
- keep `SearchResultItem` memoized for fewer renders

## Testing
- `pnpm lint`
