### PR TITLE
Fix relation labels for incoming links

### DIFF
--- a/src/app/lib/hooks/use-records.ts
+++ b/src/app/lib/hooks/use-records.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { trpc } from '@/app/trpc';
 import type { DbId } from '@/server/api/routers/common';
@@ -101,6 +102,11 @@ export function useDeleteMedia() {
 export function usePredicateMap() {
 	const { data } = trpc.links.listPredicates.useQuery(undefined);
 	return Object.fromEntries((data ?? []).map((p) => [p.id, p]));
+}
+
+export function usePredicateSlugMap() {
+	const { data } = trpc.links.listPredicates.useQuery(undefined);
+	return useMemo(() => Object.fromEntries((data ?? []).map((p) => [p.slug, p])), [data]);
 }
 
 export function useEmbedRecord() {

--- a/src/app/routes/records/-components/relations.tsx
+++ b/src/app/routes/records/-components/relations.tsx
@@ -11,6 +11,7 @@ import {
 	useDeleteLinks,
 	useMergeRecords,
 	usePredicateMap,
+	usePredicateSlugMap,
 	useRecordLinks,
 } from '@/lib/hooks/use-records';
 import { cn } from '@/lib/utils';
@@ -28,6 +29,7 @@ interface RecordLink extends LinkSelect {
 export const RelationsList = ({ id }: RelationsListProps) => {
 	const { data: recordLinks } = useRecordLinks(id);
 	const predicates = usePredicateMap();
+	const predicatesBySlug = usePredicateSlugMap();
 	const mergeRecordsMutation = useMergeRecords();
 	const deleteLinkMutation = useDeleteLinks();
 	const navigate = useNavigate();
@@ -181,7 +183,12 @@ export const RelationsList = ({ id }: RelationsListProps) => {
 						{incomingLinks.map((link) => (
 							<li key={`${link.sourceId}-${link.predicateId}`} className="flex items-center gap-2">
 								<RelationshipSelector
-									label={predicates[link.predicateId]?.name ?? 'Unknown'}
+									label={(() => {
+										const p = predicates[link.predicateId];
+										if (!p) return 'Unknown';
+										const slug = p.inverseSlug ?? p.slug;
+										return predicatesBySlug[slug]?.name ?? p.name;
+									})()}
 									sourceId={id}
 									link={link}
 									buttonProps={{


### PR DESCRIPTION
## Summary
- show inverse predicate names for incoming relations
- add predicate slug map hook

## Testing
- `pnpm lint`
