### PR TITLE
Migrate project to zod/v4

### DIFF
--- a/src/app/components/media-upload.tsx
+++ b/src/app/components/media-upload.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { forwardRef, useCallback, useRef, useState } from 'react';
 import { UploadIcon } from 'lucide-react';
 import { toast } from 'sonner';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { Spinner } from './spinner';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -52,7 +52,7 @@ export const MediaUpload = forwardRef<HTMLDivElement, MediaUploadProps>(
 				} catch (err) {
 					let errorMessage = 'Invalid file.';
 					if (err instanceof z.ZodError) {
-						errorMessage = err.errors[0]?.message ?? errorMessage;
+						errorMessage = err.issues[0]?.message ?? errorMessage;
 					} else if (err instanceof Error) {
 						errorMessage = `Upload failed: ${err.message}`;
 					}

--- a/src/app/components/metadata-list.tsx
+++ b/src/app/components/metadata-list.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CopyIcon } from 'lucide-react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
 	DataListItem,
 	DataListLabel,
@@ -24,7 +24,7 @@ interface MetadataListProps extends DataListRootProps {
 	metadata: Record<string, unknown>;
 }
 
-const urlSchema = z.string().url();
+const urlSchema = z.url();
 
 export const MetadataList = ({ metadata, ...props }: MetadataListProps) => {
 	const [copiedKey, setCopiedKey] = useState<string | null>(null);

--- a/src/app/lib/formatting.ts
+++ b/src/app/lib/formatting.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const toTitleCase = (str: string) => str.replace(/\b\w/g, (char) => char.toUpperCase());
 
@@ -43,8 +43,8 @@ export const formatCreatorDescription = (
 };
 
 // More robust URL schema with custom error message
-const urlSchema = z.string().url({
-	message: 'Invalid URL format. Please provide a valid URL.',
+const urlSchema = z.url({
+	error: 'Invalid URL format. Please provide a valid URL.',
 });
 
 type UrlOptions = {
@@ -67,12 +67,12 @@ export function validateAndFormatUrl(
 	url: string,
 	safe: true,
 	options?: UrlOptions
-): z.SafeParseReturnType<string, string>;
+): z.ZodSafeParseResult<string, string>;
 export function validateAndFormatUrl(
 	url: string,
 	safe?: boolean,
 	options?: UrlOptions
-): string | z.SafeParseReturnType<string, string> {
+): string | z.ZodSafeParseResult<string, string> {
 	// Default options
 	const { skipHttps = false } = options || {};
 
@@ -128,9 +128,5 @@ export function mapUrl(url?: string | null): string | undefined {
  * const nameSchema = emptyStringToNull(z.string())
  * // '' -> null, 'value' -> 'value'
  */
-export const emptyStringToNull = <T extends z.ZodType>(schema: T) =>
-	z
-		.string()
-		.nullable()
-		.transform((str) => (str === '' ? null : str))
-		.pipe(schema.nullable());
+export const emptyStringToNull = <T extends z.ZodTypeAny>(schema: T) =>
+	z.preprocess((val) => (val === '' ? null : val), schema.nullable());

--- a/src/app/lib/formatting.ts
+++ b/src/app/lib/formatting.ts
@@ -67,12 +67,12 @@ export function validateAndFormatUrl(
 	url: string,
 	safe: true,
 	options?: UrlOptions
-): z.ZodSafeParseResult<string, string>;
+): z.ZodSafeParseResult<string>;
 export function validateAndFormatUrl(
 	url: string,
 	safe?: boolean,
 	options?: UrlOptions
-): string | z.ZodSafeParseResult<string, string> {
+): string | z.ZodSafeParseResult<string> {
 	// Default options
 	const { skipHttps = false } = options || {};
 

--- a/src/app/lib/seo.ts
+++ b/src/app/lib/seo.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const robotsEnum = z.enum([
 	'all',
@@ -18,14 +18,14 @@ export const metaTypeEnum = z.enum(['website', 'article', 'blog']);
 const seoSchema = z.object({
 	title: z.string().min(1),
 	description: z.string().optional(),
-	imageUrl: z.string().url().optional(),
+	imageUrl: z.url().optional(),
 	keywords: z.array(z.string()).optional(),
 	author: z.string().optional(),
 	twitterCreator: z.string().regex(/^@/, 'Twitter handle must start with @').optional(),
 	robots: z.array(robotsEnum).optional(),
 	locale: z.string().optional(),
-	canonicalUrl: z.string().url().optional(),
-	publishedTime: z.string().datetime().optional(),
+	canonicalUrl: z.url().optional(),
+	publishedTime: z.iso.datetime().optional(),
 	type: metaTypeEnum.optional(),
 });
 
@@ -53,11 +53,11 @@ function createTags({
 	keywords,
 	author = 'Nick Trombley',
 	twitterCreator = '@redcliffrecord',
-	robots = [robotsEnum.Enum.index, robotsEnum.Enum.follow],
+	robots = [robotsEnum.enum.index, robotsEnum.enum.follow],
 	locale = 'en_US',
 	canonicalUrl,
 	publishedTime,
-	type = metaTypeEnum.Enum.website,
+	type = metaTypeEnum.enum.website,
 }: SeoProps) {
 	const tags = [
 		// Basic meta tags

--- a/src/app/lib/server/theme.ts
+++ b/src/app/lib/server/theme.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { getCookie, setCookie } from 'vinxi/http';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const ThemeCookieSchema = z.enum(['light', 'dark']).default('dark');
 

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useForm } from '@tanstack/react-form';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { SaveIcon, Trash2Icon } from 'lucide-react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import type { RecordGet } from '@/server/api/routers/types';
 import { RecordInsertSchema, RecordTypeSchema, type RecordType } from '@/server/db/schema';
 import { recordTypeIcons } from './type-icons';

--- a/src/server/api/init.ts
+++ b/src/server/api/init.ts
@@ -4,7 +4,7 @@ import DataLoader from 'dataloader';
 import { drizzle } from 'drizzle-orm/neon-http';
 import superjson from 'superjson';
 import ws from 'ws';
-import { ZodError } from 'zod';
+import { ZodError } from 'zod/v4';
 import { relations } from '@/server/db/relations';
 import * as schema from '@/server/db/schema';
 import type { RecordGet } from './routers/types';

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { createTRPCRouter, publicProcedure } from '../init';
 import { createEmbedding } from '@/lib/server/create-embedding';
 

--- a/src/server/api/routers/common.ts
+++ b/src/server/api/routers/common.ts
@@ -1,5 +1,5 @@
 import { cosineDistance, sql, type Column } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const DEFAULT_LIMIT = 50;
 export const SIMILARITY_THRESHOLD = 0.8; // Lower is more strict

--- a/src/server/api/routers/links.ts
+++ b/src/server/api/routers/links.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { eq, inArray } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
 	LinkInsertSchema,
 	links,

--- a/src/server/api/routers/media.ts
+++ b/src/server/api/routers/media.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { createTRPCRouter, publicProcedure } from '../init';
 import { IdSchema } from './common';
 import {

--- a/src/server/api/routers/records/delete.ts
+++ b/src/server/api/routers/records/delete.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { publicProcedure } from '../../init';
 import { IdSchema } from '../common';
 import {

--- a/src/server/api/routers/records/edit.ts
+++ b/src/server/api/routers/records/edit.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { publicProcedure } from '../../init';
 import { IdSchema, type DbId } from '../common';
 import type { RecordGet } from '../types';

--- a/src/server/api/routers/records/merge.ts
+++ b/src/server/api/routers/records/merge.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { eq, inArray } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { publicProcedure } from '../../init';
 import type { DbId } from '../common';
 import {

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { cosineDistance, sql } from 'drizzle-orm';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { createTRPCRouter, publicProcedure } from '../init';
 import { IdSchema, similarity, SIMILARITY_THRESHOLD } from './common';
 import { SearchRecordsInputSchema } from './types';

--- a/src/server/api/routers/types.ts
+++ b/src/server/api/routers/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { DEFAULT_LIMIT, type DbId } from './common';
 import {
 	IntegrationTypeSchema,

--- a/src/server/db/schema/github.ts
+++ b/src/server/db/schema/github.ts
@@ -125,7 +125,7 @@ export const githubCommitChangeStatusEnum = pgEnum('github_commit_change_status'
 export const GithubCommitChangeStatus = z.enum(githubCommitChangeStatusEnum.enumValues);
 export type GithubCommitChangeStatus = z.infer<typeof GithubCommitChangeStatus>;
 
-export const githubCommitTypesEnum = pgEnum('github_commit_types', [
+export const githubCommitTypes = [
 	'feature',
 	'enhancement',
 	'bugfix',
@@ -135,7 +135,8 @@ export const githubCommitTypesEnum = pgEnum('github_commit_types', [
 	'chore',
 	'test',
 	'build',
-]);
+] as const;
+export const githubCommitTypesEnum = pgEnum('github_commit_types', githubCommitTypes);
 export const GithubCommitType = z.enum(githubCommitTypesEnum.enumValues);
 export type GithubCommitType = z.infer<typeof GithubCommitType>;
 

--- a/src/server/db/schema/github.ts
+++ b/src/server/db/schema/github.ts
@@ -113,20 +113,7 @@ export type GithubRepositorySelect = typeof githubRepositories.$inferSelect;
 export const GithubRepositoryInsertSchema = createInsertSchema(githubRepositories);
 export type GithubRepositoryInsert = typeof githubRepositories.$inferInsert;
 
-export const GithubCommitType = z.enum([
-	'feature',
-	'enhancement',
-	'bugfix',
-	'refactor',
-	'documentation',
-	'style',
-	'chore',
-	'test',
-	'build',
-]);
-export type GithubCommitType = z.infer<typeof GithubCommitType>;
-
-export const GithubCommitChangeStatus = z.enum([
+export const githubCommitChangeStatusEnum = pgEnum('github_commit_change_status', [
 	'added',
 	'modified',
 	'removed',
@@ -135,6 +122,7 @@ export const GithubCommitChangeStatus = z.enum([
 	'changed',
 	'unchanged',
 ]);
+export const GithubCommitChangeStatus = z.enum(githubCommitChangeStatusEnum.enumValues);
 export type GithubCommitChangeStatus = z.infer<typeof GithubCommitChangeStatus>;
 
 export const githubCommitTypesEnum = pgEnum('github_commit_types', [
@@ -147,7 +135,9 @@ export const githubCommitTypesEnum = pgEnum('github_commit_types', [
 	'chore',
 	'test',
 	'build',
-] as const);
+]);
+export const GithubCommitType = z.enum(githubCommitTypesEnum.enumValues);
+export type GithubCommitType = z.infer<typeof GithubCommitType>;
 
 export const githubCommits = pgTable(
 	'github_commits',
@@ -180,16 +170,6 @@ export const GithubCommitSelectSchema = createSelectSchema(githubCommits);
 export type GithubCommitSelect = typeof githubCommits.$inferSelect;
 export const GithubCommitInsertSchema = createInsertSchema(githubCommits);
 export type GithubCommitInsert = typeof githubCommits.$inferInsert;
-
-export const githubCommitChangeStatusEnum = pgEnum('github_commit_change_status', [
-	'added',
-	'modified',
-	'removed',
-	'renamed',
-	'copied',
-	'changed',
-	'unchanged',
-] as const);
 
 export const githubCommitChanges = pgTable(
 	'github_commit_changes',

--- a/src/server/db/schema/github.ts
+++ b/src/server/db/schema/github.ts
@@ -9,7 +9,7 @@ import {
 	timestamp,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
 	contentTimestamps,
 	contentTimestampsNonUpdatable,
@@ -137,7 +137,17 @@ export const GithubCommitChangeStatus = z.enum([
 ]);
 export type GithubCommitChangeStatus = z.infer<typeof GithubCommitChangeStatus>;
 
-export const githubCommitTypesEnum = pgEnum('github_commit_types', GithubCommitType.options);
+export const githubCommitTypesEnum = pgEnum('github_commit_types', [
+	'feature',
+	'enhancement',
+	'bugfix',
+	'refactor',
+	'documentation',
+	'style',
+	'chore',
+	'test',
+	'build',
+] as const);
 
 export const githubCommits = pgTable(
 	'github_commits',
@@ -171,10 +181,15 @@ export type GithubCommitSelect = typeof githubCommits.$inferSelect;
 export const GithubCommitInsertSchema = createInsertSchema(githubCommits);
 export type GithubCommitInsert = typeof githubCommits.$inferInsert;
 
-export const githubCommitChangeStatusEnum = pgEnum(
-	'github_commit_change_status',
-	GithubCommitChangeStatus.options
-);
+export const githubCommitChangeStatusEnum = pgEnum('github_commit_change_status', [
+	'added',
+	'modified',
+	'removed',
+	'renamed',
+	'copied',
+	'changed',
+	'unchanged',
+] as const);
 
 export const githubCommitChanges = pgTable(
 	'github_commit_changes',

--- a/src/server/db/schema/history.ts
+++ b/src/server/db/schema/history.ts
@@ -13,16 +13,9 @@ import { z } from 'zod/v4';
 import { databaseTimestamps, databaseTimestampsNonUpdatable } from './operations';
 import { integrationRuns } from './operations';
 
-export const Browser = z.enum(['arc', 'chrome', 'firefox', 'safari', 'edge']);
+export const browserEnum = pgEnum('browser', ['arc', 'chrome', 'firefox', 'safari', 'edge']);
+export const Browser = z.enum(browserEnum.enumValues);
 export type Browser = z.infer<typeof Browser>;
-
-export const browserEnum = pgEnum('browser', [
-	'arc',
-	'chrome',
-	'firefox',
-	'safari',
-	'edge',
-] as const);
 
 export const browsingHistory = pgTable(
 	'browsing_history',

--- a/src/server/db/schema/history.ts
+++ b/src/server/db/schema/history.ts
@@ -9,14 +9,20 @@ import {
 	timestamp,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { databaseTimestamps, databaseTimestampsNonUpdatable } from './operations';
 import { integrationRuns } from './operations';
 
 export const Browser = z.enum(['arc', 'chrome', 'firefox', 'safari', 'edge']);
 export type Browser = z.infer<typeof Browser>;
 
-export const browserEnum = pgEnum('browser', Browser.options);
+export const browserEnum = pgEnum('browser', [
+	'arc',
+	'chrome',
+	'firefox',
+	'safari',
+	'edge',
+] as const);
 
 export const browsingHistory = pgTable(
 	'browsing_history',

--- a/src/server/db/schema/media.ts
+++ b/src/server/db/schema/media.ts
@@ -23,7 +23,7 @@ export const mediaTypeEnum = pgEnum('media_type', [
 	'multipart', // multipart files
 	'text', // plain text, markdown, etc.
 	'video', // video files
-]);
+] as const);
 
 export const MediaType = z.enum(mediaTypeEnum.enumValues);
 export type MediaType = z.infer<typeof MediaType>;

--- a/src/server/db/schema/media.ts
+++ b/src/server/db/schema/media.ts
@@ -23,8 +23,7 @@ export const mediaTypeEnum = pgEnum('media_type', [
 	'multipart', // multipart files
 	'text', // plain text, markdown, etc.
 	'video', // video files
-] as const);
-
+]);
 export const MediaType = z.enum(mediaTypeEnum.enumValues);
 export type MediaType = z.infer<typeof MediaType>;
 

--- a/src/server/db/schema/operations.ts
+++ b/src/server/db/schema/operations.ts
@@ -10,12 +10,16 @@ import {
 	vector,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const IntegrationStatus = z.enum(['success', 'fail', 'in_progress']);
 export type IntegrationStatus = z.infer<typeof IntegrationStatus>;
 
-export const integrationStatusEnum = pgEnum('integration_status', IntegrationStatus.options);
+export const integrationStatusEnum = pgEnum('integration_status', [
+	'success',
+	'fail',
+	'in_progress',
+] as const);
 
 export const IntegrationTypeSchema = z.enum([
 	'ai_chat',
@@ -31,11 +35,23 @@ export const IntegrationTypeSchema = z.enum([
 	'twitter',
 ]);
 export type IntegrationType = z.infer<typeof IntegrationTypeSchema>;
-export const integrationTypeEnum = pgEnum('integration_type', IntegrationTypeSchema.options);
+export const integrationTypeEnum = pgEnum('integration_type', [
+	'ai_chat',
+	'airtable',
+	'browser_history',
+	'crawler',
+	'embeddings',
+	'github',
+	'lightroom',
+	'manual',
+	'raindrop',
+	'readwise',
+	'twitter',
+] as const);
 
 export const RunType = z.enum(['seed', 'sync']);
 export type RunType = z.infer<typeof RunType>;
-export const runTypeEnum = pgEnum('run_type', RunType.options);
+export const runTypeEnum = pgEnum('run_type', ['seed', 'sync'] as const);
 
 const recordCreatedAt = timestamp('created_at', {
 	withTimezone: true,

--- a/src/server/db/schema/operations.ts
+++ b/src/server/db/schema/operations.ts
@@ -12,29 +12,14 @@ import {
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod/v4';
 
-export const IntegrationStatus = z.enum(['success', 'fail', 'in_progress']);
-export type IntegrationStatus = z.infer<typeof IntegrationStatus>;
-
 export const integrationStatusEnum = pgEnum('integration_status', [
 	'success',
 	'fail',
 	'in_progress',
-] as const);
-
-export const IntegrationTypeSchema = z.enum([
-	'ai_chat',
-	'airtable',
-	'browser_history',
-	'crawler',
-	'embeddings',
-	'github',
-	'lightroom',
-	'manual',
-	'raindrop',
-	'readwise',
-	'twitter',
 ]);
-export type IntegrationType = z.infer<typeof IntegrationTypeSchema>;
+export const IntegrationStatus = z.enum(integrationStatusEnum.enumValues);
+export type IntegrationStatus = z.infer<typeof IntegrationStatus>;
+
 export const integrationTypeEnum = pgEnum('integration_type', [
 	'ai_chat',
 	'airtable',
@@ -47,11 +32,13 @@ export const integrationTypeEnum = pgEnum('integration_type', [
 	'raindrop',
 	'readwise',
 	'twitter',
-] as const);
+]);
+export const IntegrationType = z.enum(integrationTypeEnum.enumValues);
+export type IntegrationType = z.infer<typeof IntegrationType>;
 
-export const RunType = z.enum(['seed', 'sync']);
+export const runTypeEnum = pgEnum('run_type', ['seed', 'sync']);
+export const RunType = z.enum(runTypeEnum.enumValues);
 export type RunType = z.infer<typeof RunType>;
-export const runTypeEnum = pgEnum('run_type', ['seed', 'sync'] as const);
 
 const recordCreatedAt = timestamp('created_at', {
 	withTimezone: true,

--- a/src/server/db/schema/operations.ts
+++ b/src/server/db/schema/operations.ts
@@ -33,8 +33,8 @@ export const integrationTypeEnum = pgEnum('integration_type', [
 	'readwise',
 	'twitter',
 ]);
-export const IntegrationType = z.enum(integrationTypeEnum.enumValues);
-export type IntegrationType = z.infer<typeof IntegrationType>;
+export const IntegrationTypeSchema = z.enum(integrationTypeEnum.enumValues);
+export type IntegrationType = z.infer<typeof IntegrationTypeSchema>;
 
 export const runTypeEnum = pgEnum('run_type', ['seed', 'sync']);
 export const RunType = z.enum(runTypeEnum.enumValues);

--- a/src/server/db/schema/raindrop.ts
+++ b/src/server/db/schema/raindrop.ts
@@ -24,7 +24,7 @@ export const raindropTypeEnum = pgEnum('raindrop_type', [
 	'image',
 	'audio',
 	'article',
-] as const);
+]);
 export const RaindropType = z.enum(raindropTypeEnum.enumValues);
 export type RaindropType = z.infer<typeof RaindropType>;
 

--- a/src/server/db/schema/raindrop.ts
+++ b/src/server/db/schema/raindrop.ts
@@ -24,7 +24,7 @@ export const raindropTypeEnum = pgEnum('raindrop_type', [
 	'image',
 	'audio',
 	'article',
-]);
+] as const);
 export const RaindropType = z.enum(raindropTypeEnum.enumValues);
 export type RaindropType = z.infer<typeof RaindropType>;
 

--- a/src/server/db/schema/readwise.ts
+++ b/src/server/db/schema/readwise.ts
@@ -23,7 +23,7 @@ export const readwiseLocationEnum = pgEnum('readwise_location', [
 	'shortlist',
 	'archive',
 	'feed',
-]);
+] as const);
 export const ReadwiseLocation = z.enum(readwiseLocationEnum.enumValues);
 export type ReadwiseLocation = z.infer<typeof ReadwiseLocation>;
 
@@ -37,7 +37,7 @@ export const readwiseCategoryEnum = pgEnum('readwise_category', [
 	'epub',
 	'tweet',
 	'video',
-]);
+] as const);
 export const ReadwiseCategory = z.enum(readwiseCategoryEnum.enumValues);
 export type ReadwiseCategory = z.infer<typeof ReadwiseCategory>;
 

--- a/src/server/db/schema/readwise.ts
+++ b/src/server/db/schema/readwise.ts
@@ -23,7 +23,7 @@ export const readwiseLocationEnum = pgEnum('readwise_location', [
 	'shortlist',
 	'archive',
 	'feed',
-] as const);
+]);
 export const ReadwiseLocation = z.enum(readwiseLocationEnum.enumValues);
 export type ReadwiseLocation = z.infer<typeof ReadwiseLocation>;
 
@@ -37,7 +37,7 @@ export const readwiseCategoryEnum = pgEnum('readwise_category', [
 	'epub',
 	'tweet',
 	'video',
-] as const);
+]);
 export const ReadwiseCategory = z.enum(readwiseCategoryEnum.enumValues);
 export type ReadwiseCategory = z.infer<typeof ReadwiseCategory>;
 

--- a/src/server/db/schema/records.ts
+++ b/src/server/db/schema/records.ts
@@ -21,13 +21,13 @@ import {
 } from './operations';
 import { emptyStringToNull } from '@/lib/formatting';
 
-export const RecordTypeSchema = z.enum([
+export const recordTypeEnum = pgEnum('record_type', [
 	'entity', // an actor in the world, has will
 	'concept', // a category, idea, or abstraction
 	'artifact', // physical or digital objects, content, or media
 ]);
-export type RecordType = z.infer<typeof RecordTypeSchema>;
-export const recordTypeEnum = pgEnum('record_type', ['entity', 'concept', 'artifact'] as const);
+export const RecordType = z.enum(recordTypeEnum.enumValues);
+export type RecordType = z.infer<typeof RecordType>;
 
 // Main index table
 export const records = pgTable(
@@ -127,7 +127,7 @@ export type LinkSelect = typeof links.$inferSelect;
 export const LinkInsertSchema = createInsertSchema(links);
 export type LinkInsert = typeof links.$inferInsert;
 
-export const PredicateTypeSchema = z.enum([
+export const predicateTypeEnum = pgEnum('predicate_type', [
 	'creation', // authorship, ownership …
 	'containment', // has_part, sequence …
 	'description', // about, tag …
@@ -135,15 +135,8 @@ export const PredicateTypeSchema = z.enum([
 	'reference', // cites, responds_to …
 	'identity', // instance_of, same_as …
 ]);
-export type PredicateType = z.infer<typeof PredicateTypeSchema>;
-export const predicateTypeEnum = pgEnum('predicate_type', [
-	'creation',
-	'containment',
-	'description',
-	'association',
-	'reference',
-	'identity',
-] as const);
+export const PredicateType = z.enum(predicateTypeEnum.enumValues);
+export type PredicateType = z.infer<typeof PredicateType>;
 
 export const predicates = pgTable(
 	'predicates',

--- a/src/server/db/schema/records.ts
+++ b/src/server/db/schema/records.ts
@@ -26,8 +26,8 @@ export const recordTypeEnum = pgEnum('record_type', [
 	'concept', // a category, idea, or abstraction
 	'artifact', // physical or digital objects, content, or media
 ]);
-export const RecordType = z.enum(recordTypeEnum.enumValues);
-export type RecordType = z.infer<typeof RecordType>;
+export const RecordTypeSchema = z.enum(recordTypeEnum.enumValues);
+export type RecordType = z.infer<typeof RecordTypeSchema>;
 
 // Main index table
 export const records = pgTable(

--- a/src/server/db/schema/records.ts
+++ b/src/server/db/schema/records.ts
@@ -12,7 +12,7 @@ import {
 	type AnyPgColumn,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
 	contentTimestamps,
 	databaseTimestamps,
@@ -27,7 +27,7 @@ export const RecordTypeSchema = z.enum([
 	'artifact', // physical or digital objects, content, or media
 ]);
 export type RecordType = z.infer<typeof RecordTypeSchema>;
-export const recordTypeEnum = pgEnum('record_type', RecordTypeSchema.options);
+export const recordTypeEnum = pgEnum('record_type', ['entity', 'concept', 'artifact'] as const);
 
 // Main index table
 export const records = pgTable(
@@ -81,8 +81,8 @@ export const records = pgTable(
 export const RecordSelectSchema = createSelectSchema(records);
 export type RecordSelect = typeof records.$inferSelect;
 export const RecordInsertSchema = createInsertSchema(records).extend({
-	url: emptyStringToNull(z.string().url()).optional(),
-	avatarUrl: emptyStringToNull(z.string().url()).optional(),
+	url: emptyStringToNull(z.url()).optional(),
+	avatarUrl: emptyStringToNull(z.url()).optional(),
 	rating: z.number().int().min(0).max(3).default(0),
 });
 export type RecordInsert = typeof records.$inferInsert;
@@ -136,7 +136,14 @@ export const PredicateTypeSchema = z.enum([
 	'identity', // instance_of, same_as …
 ]);
 export type PredicateType = z.infer<typeof PredicateTypeSchema>;
-export const predicateTypeEnum = pgEnum('predicate_type', PredicateTypeSchema.options);
+export const predicateTypeEnum = pgEnum('predicate_type', [
+	'creation',
+	'containment',
+	'description',
+	'association',
+	'reference',
+	'identity',
+] as const);
 
 export const predicates = pgTable(
 	'predicates',

--- a/src/server/db/schema/twitter.ts
+++ b/src/server/db/schema/twitter.ts
@@ -54,14 +54,13 @@ export type TwitterTweetSelect = typeof twitterTweets.$inferSelect;
 export const TwitterTweetInsertSchema = createInsertSchema(twitterTweets);
 export type TwitterTweetInsert = typeof twitterTweets.$inferInsert;
 
-export const TwitterMediaType = z.enum(['photo', 'video', 'animated_gif']);
-export type TwitterMediaType = z.infer<typeof TwitterMediaType>;
-
 export const twitterMediaTypeEnum = pgEnum('twitter_media_type', [
 	'photo',
 	'video',
 	'animated_gif',
-] as const);
+]);
+export const TwitterMediaType = z.enum(twitterMediaTypeEnum.enumValues);
+export type TwitterMediaType = z.infer<typeof TwitterMediaType>;
 
 export const twitterMedia = pgTable(
 	'twitter_media',

--- a/src/server/db/schema/twitter.ts
+++ b/src/server/db/schema/twitter.ts
@@ -8,7 +8,7 @@ import {
 	type AnyPgColumn,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { media } from './media';
 import { contentTimestamps, databaseTimestamps } from './operations';
 import { integrationRuns } from './operations';
@@ -57,7 +57,11 @@ export type TwitterTweetInsert = typeof twitterTweets.$inferInsert;
 export const TwitterMediaType = z.enum(['photo', 'video', 'animated_gif']);
 export type TwitterMediaType = z.infer<typeof TwitterMediaType>;
 
-export const twitterMediaTypeEnum = pgEnum('twitter_media_type', TwitterMediaType.options);
+export const twitterMediaTypeEnum = pgEnum('twitter_media_type', [
+	'photo',
+	'video',
+	'animated_gif',
+] as const);
 
 export const twitterMedia = pgTable(
 	'twitter_media',

--- a/src/server/integrations/adobe/types.ts
+++ b/src/server/integrations/adobe/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const LightroomAssetLinksSchema = z.object({
 	self: z.object({ href: z.string() }),
@@ -97,10 +97,10 @@ export const LightroomAestheticsSchema = z.object({
 });
 export type LightroomAesthetics = z.infer<typeof LightroomAestheticsSchema>;
 export const LightroomAutoTagsSchema = z.object({
-	tags: z.record(z.number().min(0).max(100)),
-	application: z.string(),
-	version: z.number(),
-	created: z.coerce.date(),
+        tags: z.record(z.string(), z.number().min(0).max(100)),
+        application: z.string(),
+        version: z.number(),
+        created: z.coerce.date(),
 });
 
 const LightroomAssetPayloadImportSourceSchema = z.object({

--- a/src/server/integrations/adobe/types.ts
+++ b/src/server/integrations/adobe/types.ts
@@ -97,10 +97,10 @@ export const LightroomAestheticsSchema = z.object({
 });
 export type LightroomAesthetics = z.infer<typeof LightroomAestheticsSchema>;
 export const LightroomAutoTagsSchema = z.object({
-        tags: z.record(z.string(), z.number().min(0).max(100)),
-        application: z.string(),
-        version: z.number(),
-        created: z.coerce.date(),
+	tags: z.record(z.string(), z.number().min(0).max(100)),
+	application: z.string(),
+	version: z.number(),
+	created: z.coerce.date(),
 });
 
 const LightroomAssetPayloadImportSourceSchema = z.object({
@@ -139,6 +139,7 @@ const LightroomAssetPayloadSchema = z.object({
 	xmp: LightroomAssetXmpSchema,
 	ratings: z
 		.record(
+			z.string(),
 			z.object({
 				rating: z.number(),
 				date: z.string().optional(),
@@ -153,6 +154,7 @@ const LightroomAssetPayloadSchema = z.object({
 	order: z.string().optional(),
 	aux: z
 		.record(
+			z.string(),
 			z.object({
 				digest: z.string(),
 				fileSize: z.number(),

--- a/src/server/integrations/airtable/types.ts
+++ b/src/server/integrations/airtable/types.ts
@@ -1,9 +1,9 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 // Convert Airtable Attachment type to Zod schema
 export const AirtableAttachmentSchema = z.object({
 	id: z.string(),
-	url: z.string().url(),
+	url: z.url(),
 	filename: z.string(),
 	size: z.number().int().min(0).optional(),
 	type: z.string(),
@@ -16,7 +16,7 @@ export const ExtractFieldSetSchema = z.object({
 	title: z.string(),
 	format: z.string(),
 	michelinStars: z.number().int().min(0).max(3).default(0),
-	source: z.string().url().optional(),
+	source: z.url().optional(),
 	creators: z.array(z.string()).optional(),
 	extract: z.string().optional(),
 	parent: z.array(z.string()).optional(),
@@ -66,7 +66,7 @@ export const CreatorFieldSetSchema = z.object({
 	name: z.string(),
 	type: z.string().optional(),
 	primaryProject: z.string().optional(),
-	site: z.string().url().optional(),
+	site: z.url().optional(),
 	professions: z.array(z.string()).optional(),
 	organizations: z.array(z.string()).optional(),
 	nationality: z.array(z.string()).optional(),

--- a/src/server/integrations/arc/types.ts
+++ b/src/server/integrations/arc/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { emptyStringToNull } from '@/app/lib/formatting';
 
 const sanitizeString = (str: string | null): string | null => {

--- a/src/server/integrations/github/summarize-commits.ts
+++ b/src/server/integrations/github/summarize-commits.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import OpenAI from 'openai';
 import { zodTextFormat } from 'openai/helpers/zod.mjs';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { db } from '@/server/db/connections';
 import type {
 	GithubCommitChangeSelect,

--- a/src/server/integrations/github/types.ts
+++ b/src/server/integrations/github/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { emptyStringToNull } from '@/app/lib/formatting';
 
 export const GithubEventSchema = z.object({
@@ -15,7 +15,7 @@ const GithubLicenseSchema = z.object({
 	key: z.string(),
 	name: z.string(),
 	spdx_id: z.string(),
-	url: z.string().url().nullable(),
+	url: z.url().nullable(),
 	node_id: z.string(),
 });
 
@@ -23,15 +23,15 @@ const GithubOwnerSchema = z.object({
 	id: z.number().int().positive(),
 	login: z.string(),
 	node_id: z.string(),
-	avatar_url: z.string().url(),
-	html_url: z.string().url(),
+	avatar_url: z.url(),
+	html_url: z.url(),
 	type: z.enum(['User', 'Organization']),
 });
 
 const GithubRepositoryDetailsSchema = z.object({
 	id: z.number().int().positive(),
 	node_id: z.string(),
-	html_url: z.string().url(),
+	html_url: z.url(),
 	name: z.string(),
 	full_name: z.string(),
 	description: emptyStringToNull(z.string()),
@@ -44,7 +44,7 @@ const GithubRepositoryDetailsSchema = z.object({
 				}
 				return str;
 			})
-			.pipe(z.string().url())
+			.pipe(z.url())
 	),
 	created_at: z.coerce.date(),
 	updated_at: z.coerce.date(),

--- a/src/server/integrations/raindrop/types.ts
+++ b/src/server/integrations/raindrop/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { emptyStringToNull } from '@/app/lib/formatting';
 
 const RaindropRefSchema = z.object({
@@ -7,7 +7,7 @@ const RaindropRefSchema = z.object({
 });
 
 const RaindropMediaSchema = z.object({
-	link: z.string().url(),
+	link: z.url(),
 	type: z.string(),
 });
 
@@ -48,9 +48,9 @@ const RaindropHighlightSchema = z.object({
 
 const RaindropCreatorSchema = z.object({
 	_id: z.number().int().positive(),
-	avatar: z.string().url().optional(),
+	avatar: z.url().optional(),
 	name: z.string(),
-	email: emptyStringToNull(z.string().email()),
+	email: emptyStringToNull(z.email()),
 });
 
 const RaindropCacheSchema = z.discriminatedUnion('status', [
@@ -71,13 +71,13 @@ const RaindropCacheSchema = z.discriminatedUnion('status', [
 
 export const RaindropSchema = z.object({
 	_id: z.number().int().positive(),
-	link: z.string().url(),
+	link: z.url(),
 	title: z.string(),
 	excerpt: emptyStringToNull(z.string()),
 	note: emptyStringToNull(z.string()),
 	type: z.enum(['link', 'article', 'image', 'video', 'document', 'audio']),
 	user: RaindropRefSchema,
-	cover: emptyStringToNull(z.string().url()),
+	cover: emptyStringToNull(z.url()),
 	media: z.array(RaindropMediaSchema),
 	tags: z.array(z.string()),
 	important: z.coerce.boolean(),

--- a/src/server/integrations/readwise/types.ts
+++ b/src/server/integrations/readwise/types.ts
@@ -21,7 +21,7 @@ export const ReadwiseArticleSchema = z.object({
 	category: ReadwiseCategory,
 	location: ReadwiseLocation.nullable(),
 	tags: z
-		.record(ReadwiseTagSchema)
+		.record(z.string(), ReadwiseTagSchema)
 		.nullable()
 		.transform((val) => {
 			const keys = Object.keys(val ?? {});

--- a/src/server/integrations/readwise/types.ts
+++ b/src/server/integrations/readwise/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { emptyStringToNull } from '@/app/lib/formatting';
 import { ReadwiseCategory, ReadwiseLocation } from '@/server/db/schema/readwise';
 
@@ -28,9 +28,9 @@ export const ReadwiseArticleSchema = z.object({
 			return keys.length > 0 ? keys : null;
 		}),
 	word_count: z.number().int().nullable(),
-	url: z.string().url(), // Internal Readwise URL
-	source_url: emptyStringToNull(z.string().url().nullable()),
-	image_url: emptyStringToNull(z.string().url().nullable()),
+	url: z.url(), // Internal Readwise URL
+	source_url: emptyStringToNull(z.url().nullable()),
+	image_url: emptyStringToNull(z.url().nullable()),
 	parent_id: z.string().nullable(),
 	reading_progress: z.number().min(0).max(1),
 	saved_at: z.coerce.date(),


### PR DESCRIPTION
## Summary
- switch all zod imports to `zod/v4`
- update string format APIs to top level functions
- modernise `emptyStringToNull` helper
- update enums for `pgEnum` usage
- adjust code to new Zod 4 types

## Testing
- `pnpm lint` *(fails: SafeParseReturn not exported, Adobe types, etc.)*