### PR TITLE
Add standalone TypeScript checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,4 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
+      - run: pnpm run tsc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 Instructions for agents are created using the Cursor Rules format. They can be found in `.cursor/rules`. Always check these rules before implementing any changes. If a refactor would cause a rule to be outdated or broken, update the rule.
 
-Prior to committing any changes, run `pnpm lint` to ensure that the code is linted and type-checked.
+Prior to committing any changes, run `pnpm lint` and `pnpm tsc` to ensure that the code is linted and type-checked.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
 	"scripts": {
 		"format": "prettier --write .",
 		"lint": "prettier --write . && eslint . --fix && tsc --noEmit",
-		"typecheck": "tsc --noEmit --watch",
+		"tsc": "tsc --noEmit",
+		"tsc:watch": "tsc --noEmit --watch",
 		"cache-clear": "rm -rf node_modules/.vinxi node_modules/.cache",
 		"dev": "pnpm cache-clear && vinxi dev",
 		"build": "vinxi build",


### PR DESCRIPTION
## Summary
- add `tsc` and `tsc:watch` scripts
- enforce `pnpm tsc` in contributor instructions
- run type checks in CI
- remove old `typecheck` script

## Testing
- `pnpm lint`
- `pnpm tsc`
