### PR TITLE
Fix fullscreen autoplay bug on Safari

### DIFF
--- a/src/app/routes/records/-components/record-link.tsx
+++ b/src/app/routes/records/-components/record-link.tsx
@@ -183,6 +183,7 @@ export const RecordLink = memo(({ id, className, linkOptions, actions }: RecordL
 							src={mediaItem.url}
 							className="absolute inset-0 size-full object-cover"
 							autoPlay
+							playsInline
 							muted
 							loop
 						/>

--- a/src/app/routes/records/-components/search-result-item.tsx
+++ b/src/app/routes/records/-components/search-result-item.tsx
@@ -83,7 +83,7 @@ export const SearchResultItem = memo(function SearchResultItem({
 							decoding="async"
 						/>
 					) : (
-						<LazyVideo src={mediaItem.url} className="absolute inset-0 object-cover" />
+						<LazyVideo src={mediaItem.url} className="absolute inset-0 object-cover" playsInline />
 					)}
 				</div>
 			)}


### PR DESCRIPTION
## Summary
- allow inline playback for small videos in record links and search results

## Testing
- `pnpm lint`
- `pnpm tsc`


------
https://chatgpt.com/codex/tasks/task_e_6853f96b59a0832290dfd1b9afa93e6d