### PR TITLE
Add cloud sync controls

### DIFF
--- a/src/app/routes/integrations/index.tsx
+++ b/src/app/routes/integrations/index.tsx
@@ -41,6 +41,111 @@ function RouteComponent() {
 		raindropMutation.mutate();
 	};
 
+	const airtableMutation = trpc.integrations.runAirtable.useMutation({
+		onSuccess: (data) => {
+			setMessages(data.messages);
+		},
+		onError: (error) => {
+			setMessages((prev) => [
+				...prev,
+				{
+					type: 'error',
+					message: error.message,
+					timestamp: new Date(),
+				},
+			]);
+		},
+	});
+
+	const handleRunAirtable = () => {
+		setMessages([]);
+		airtableMutation.mutate();
+	};
+
+	const adobeMutation = trpc.integrations.runAdobe.useMutation({
+		onSuccess: (data) => {
+			setMessages(data.messages);
+		},
+		onError: (error) => {
+			setMessages((prev) => [
+				...prev,
+				{
+					type: 'error',
+					message: error.message,
+					timestamp: new Date(),
+				},
+			]);
+		},
+	});
+
+	const handleRunAdobe = () => {
+		setMessages([]);
+		adobeMutation.mutate();
+	};
+
+	const readwiseMutation = trpc.integrations.runReadwise.useMutation({
+		onSuccess: (data) => {
+			setMessages(data.messages);
+		},
+		onError: (error) => {
+			setMessages((prev) => [
+				...prev,
+				{
+					type: 'error',
+					message: error.message,
+					timestamp: new Date(),
+				},
+			]);
+		},
+	});
+
+	const handleRunReadwise = () => {
+		setMessages([]);
+		readwiseMutation.mutate();
+	};
+
+	const feedbinMutation = trpc.integrations.runFeedbin.useMutation({
+		onSuccess: (data) => {
+			setMessages(data.messages);
+		},
+		onError: (error) => {
+			setMessages((prev) => [
+				...prev,
+				{
+					type: 'error',
+					message: error.message,
+					timestamp: new Date(),
+				},
+			]);
+		},
+	});
+
+	const handleRunFeedbin = () => {
+		setMessages([]);
+		feedbinMutation.mutate();
+	};
+
+	const githubMutation = trpc.integrations.runGithub.useMutation({
+		onSuccess: (data) => {
+			setMessages(data.messages);
+		},
+		onError: (error) => {
+			setMessages((prev) => [
+				...prev,
+				{
+					type: 'error',
+					message: error.message,
+					timestamp: new Date(),
+				},
+			]);
+		},
+	});
+
+	const handleRunGithub = () => {
+		setMessages([]);
+		githubMutation.mutate();
+	};
+
 	const getMessageIcon = (type: LogMessage['type']) => {
 		switch (type) {
 			case 'success':
@@ -119,6 +224,131 @@ function RouteComponent() {
 								</div>
 							)}
 						</div>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Airtable</CardTitle>
+						<CardDescription>Sync data from your Airtable base</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Button
+							onClick={handleRunAirtable}
+							disabled={airtableMutation.isPending}
+							className="flex items-center gap-2"
+						>
+							{airtableMutation.isPending ? (
+								<>
+									<Spinner className="size-4" />
+									Running...
+								</>
+							) : (
+								<>
+									<PlayIcon className="size-4" />
+									Run Sync
+								</>
+							)}
+						</Button>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Adobe Lightroom</CardTitle>
+						<CardDescription>Sync photos from your Lightroom album</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Button
+							onClick={handleRunAdobe}
+							disabled={adobeMutation.isPending}
+							className="flex items-center gap-2"
+						>
+							{adobeMutation.isPending ? (
+								<>
+									<Spinner className="size-4" />
+									Running...
+								</>
+							) : (
+								<>
+									<PlayIcon className="size-4" />
+									Run Sync
+								</>
+							)}
+						</Button>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Readwise</CardTitle>
+						<CardDescription>Sync highlights from Readwise</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Button
+							onClick={handleRunReadwise}
+							disabled={readwiseMutation.isPending}
+							className="flex items-center gap-2"
+						>
+							{readwiseMutation.isPending ? (
+								<>
+									<Spinner className="size-4" />
+									Running...
+								</>
+							) : (
+								<>
+									<PlayIcon className="size-4" />
+									Run Sync
+								</>
+							)}
+						</Button>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>Feedbin</CardTitle>
+						<CardDescription>Sync RSS entries from Feedbin</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Button
+							onClick={handleRunFeedbin}
+							disabled={feedbinMutation.isPending}
+							className="flex items-center gap-2"
+						>
+							{feedbinMutation.isPending ? (
+								<>
+									<Spinner className="size-4" />
+									Running...
+								</>
+							) : (
+								<>
+									<PlayIcon className="size-4" />
+									Run Sync
+								</>
+							)}
+						</Button>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader>
+						<CardTitle>GitHub</CardTitle>
+						<CardDescription>Sync repositories and activity from GitHub</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Button
+							onClick={handleRunGithub}
+							disabled={githubMutation.isPending}
+							className="flex items-center gap-2"
+						>
+							{githubMutation.isPending ? (
+								<>
+									<Spinner className="size-4" />
+									Running...
+								</>
+							) : (
+								<>
+									<PlayIcon className="size-4" />
+									Run Sync
+								</>
+							)}
+						</Button>
 					</CardContent>
 				</Card>
 			</div>

--- a/src/server/api/routers/integrations.ts
+++ b/src/server/api/routers/integrations.ts
@@ -1,5 +1,10 @@
 import { TRPCError } from '@trpc/server';
+import { syncLightroomImages } from '../../integrations/adobe/sync';
+import { syncAirtableData } from '../../integrations/airtable/sync';
+import { syncFeedbin } from '../../integrations/feedbin/sync';
+import { syncGitHubData } from '../../integrations/github/sync';
 import { syncRaindropData } from '../../integrations/raindrop/sync';
+import { syncReadwiseDocuments } from '../../integrations/readwise/sync';
 import { createTRPCRouter, publicProcedure } from '../init';
 
 interface LogMessage {
@@ -105,6 +110,446 @@ export const integrationsRouter = createTRPCRouter({
 			});
 		} finally {
 			// Restore console methods
+			console.log = originalConsoleLog;
+			console.error = originalConsoleError;
+			console.warn = originalConsoleWarn;
+		}
+	}),
+	runAirtable: publicProcedure.mutation(async (): Promise<IntegrationResult> => {
+		const messages: LogMessage[] = [];
+		let entriesCreated = 0;
+
+		const originalConsoleLog = console.log;
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+
+		console.log = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			const entryMatch = message.match(/Successfully created (\d+) entries/);
+			if (entryMatch && entryMatch[1]) {
+				entriesCreated = parseInt(entryMatch[1], 10);
+			}
+
+			messages.push({
+				type: 'info',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleLog(...args);
+		};
+
+		console.error = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'error',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleError(...args);
+		};
+
+		console.warn = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'warn',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleWarn(...args);
+		};
+
+		try {
+			await syncAirtableData();
+
+			messages.push({
+				type: 'success',
+				message: `Airtable sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+				timestamp: new Date(),
+			});
+
+			return {
+				success: true,
+				messages,
+				entriesCreated,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+			messages.push({
+				type: 'error',
+				message: `Sync failed: ${errorMessage}`,
+				timestamp: new Date(),
+			});
+
+			throw new TRPCError({
+				code: 'INTERNAL_SERVER_ERROR',
+				message: `Airtable sync failed: ${errorMessage}`,
+			});
+		} finally {
+			console.log = originalConsoleLog;
+			console.error = originalConsoleError;
+			console.warn = originalConsoleWarn;
+		}
+	}),
+	runAdobe: publicProcedure.mutation(async (): Promise<IntegrationResult> => {
+		const messages: LogMessage[] = [];
+		let entriesCreated = 0;
+
+		const originalConsoleLog = console.log;
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+
+		console.log = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			const entryMatch = message.match(/Successfully created (\d+) entries/);
+			if (entryMatch && entryMatch[1]) {
+				entriesCreated = parseInt(entryMatch[1], 10);
+			}
+
+			messages.push({
+				type: 'info',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleLog(...args);
+		};
+
+		console.error = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'error',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleError(...args);
+		};
+
+		console.warn = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'warn',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleWarn(...args);
+		};
+
+		try {
+			await syncLightroomImages();
+
+			messages.push({
+				type: 'success',
+				message: `Adobe sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+				timestamp: new Date(),
+			});
+
+			return {
+				success: true,
+				messages,
+				entriesCreated,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+			messages.push({
+				type: 'error',
+				message: `Sync failed: ${errorMessage}`,
+				timestamp: new Date(),
+			});
+
+			throw new TRPCError({
+				code: 'INTERNAL_SERVER_ERROR',
+				message: `Adobe sync failed: ${errorMessage}`,
+			});
+		} finally {
+			console.log = originalConsoleLog;
+			console.error = originalConsoleError;
+			console.warn = originalConsoleWarn;
+		}
+	}),
+	runReadwise: publicProcedure.mutation(async (): Promise<IntegrationResult> => {
+		const messages: LogMessage[] = [];
+		let entriesCreated = 0;
+
+		const originalConsoleLog = console.log;
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+
+		console.log = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			const entryMatch = message.match(/Successfully created (\d+) entries/);
+			if (entryMatch && entryMatch[1]) {
+				entriesCreated = parseInt(entryMatch[1], 10);
+			}
+
+			messages.push({
+				type: 'info',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleLog(...args);
+		};
+
+		console.error = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'error',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleError(...args);
+		};
+
+		console.warn = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'warn',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleWarn(...args);
+		};
+
+		try {
+			await syncReadwiseDocuments();
+
+			messages.push({
+				type: 'success',
+				message: `Readwise sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+				timestamp: new Date(),
+			});
+
+			return {
+				success: true,
+				messages,
+				entriesCreated,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+			messages.push({
+				type: 'error',
+				message: `Sync failed: ${errorMessage}`,
+				timestamp: new Date(),
+			});
+
+			throw new TRPCError({
+				code: 'INTERNAL_SERVER_ERROR',
+				message: `Readwise sync failed: ${errorMessage}`,
+			});
+		} finally {
+			console.log = originalConsoleLog;
+			console.error = originalConsoleError;
+			console.warn = originalConsoleWarn;
+		}
+	}),
+	runFeedbin: publicProcedure.mutation(async (): Promise<IntegrationResult> => {
+		const messages: LogMessage[] = [];
+		let entriesCreated = 0;
+
+		const originalConsoleLog = console.log;
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+
+		console.log = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			const entryMatch = message.match(/Successfully created (\d+) entries/);
+			if (entryMatch && entryMatch[1]) {
+				entriesCreated = parseInt(entryMatch[1], 10);
+			}
+
+			messages.push({
+				type: 'info',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleLog(...args);
+		};
+
+		console.error = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'error',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleError(...args);
+		};
+
+		console.warn = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'warn',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleWarn(...args);
+		};
+
+		try {
+			await syncFeedbin();
+
+			messages.push({
+				type: 'success',
+				message: `Feedbin sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+				timestamp: new Date(),
+			});
+
+			return {
+				success: true,
+				messages,
+				entriesCreated,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+			messages.push({
+				type: 'error',
+				message: `Sync failed: ${errorMessage}`,
+				timestamp: new Date(),
+			});
+
+			throw new TRPCError({
+				code: 'INTERNAL_SERVER_ERROR',
+				message: `Feedbin sync failed: ${errorMessage}`,
+			});
+		} finally {
+			console.log = originalConsoleLog;
+			console.error = originalConsoleError;
+			console.warn = originalConsoleWarn;
+		}
+	}),
+	runGithub: publicProcedure.mutation(async (): Promise<IntegrationResult> => {
+		const messages: LogMessage[] = [];
+		let entriesCreated = 0;
+
+		const originalConsoleLog = console.log;
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+
+		console.log = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			const entryMatch = message.match(/Successfully created (\d+) entries/);
+			if (entryMatch && entryMatch[1]) {
+				entriesCreated = parseInt(entryMatch[1], 10);
+			}
+
+			messages.push({
+				type: 'info',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleLog(...args);
+		};
+
+		console.error = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'error',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleError(...args);
+		};
+
+		console.warn = (...args: unknown[]) => {
+			const message = args
+				.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+				.join(' ');
+
+			messages.push({
+				type: 'warn',
+				message,
+				timestamp: new Date(),
+			});
+
+			originalConsoleWarn(...args);
+		};
+
+		try {
+			await syncGitHubData();
+
+			messages.push({
+				type: 'success',
+				message: `GitHub sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+				timestamp: new Date(),
+			});
+
+			return {
+				success: true,
+				messages,
+				entriesCreated,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+			messages.push({
+				type: 'error',
+				message: `Sync failed: ${errorMessage}`,
+				timestamp: new Date(),
+			});
+
+			throw new TRPCError({
+				code: 'INTERNAL_SERVER_ERROR',
+				message: `GitHub sync failed: ${errorMessage}`,
+			});
+		} finally {
 			console.log = originalConsoleLog;
 			console.error = originalConsoleError;
 			console.warn = originalConsoleWarn;


### PR DESCRIPTION
## Summary
- add mutation endpoints for Airtable, Adobe, Readwise, Feedbin and GitHub
- add buttons on integrations page to trigger each cloud sync

## Testing
- `pnpm lint`
- `pnpm tsc`


------
https://chatgpt.com/codex/tasks/task_e_688b29f47f608322924ed6873ede8715