### PR TITLE
Enable local file uploads for browser history and Twitter syncs

### DIFF
--- a/src/server/api/routers/integrations.ts
+++ b/src/server/api/routers/integrations.ts
@@ -1,10 +1,13 @@
 import { TRPCError } from '@trpc/server';
+import { z } from 'zod/v4';
 import { syncLightroomImages } from '../../integrations/adobe/sync';
 import { syncAirtableData } from '../../integrations/airtable/sync';
+import { syncAllBrowserData } from '../../integrations/browser-history/sync-all';
 import { syncFeedbin } from '../../integrations/feedbin/sync';
 import { syncGitHubData } from '../../integrations/github/sync';
 import { syncRaindropData } from '../../integrations/raindrop/sync';
 import { syncReadwiseDocuments } from '../../integrations/readwise/sync';
+import { parseBookmarkDataStrings, syncTwitterData } from '../../integrations/twitter/sync';
 import { createTRPCRouter, publicProcedure } from '../init';
 
 interface LogMessage {
@@ -555,4 +558,190 @@ export const integrationsRouter = createTRPCRouter({
 			console.warn = originalConsoleWarn;
 		}
 	}),
+	runBrowsing: publicProcedure
+		.input(z.object({ arc: z.string().optional(), dia: z.string().optional() }))
+		.mutation(async ({ input }): Promise<IntegrationResult> => {
+			const messages: LogMessage[] = [];
+			let entriesCreated = 0;
+
+			const originalConsoleLog = console.log;
+			const originalConsoleError = console.error;
+			const originalConsoleWarn = console.warn;
+
+			console.log = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				const entryMatch = message.match(/Successfully created (\d+) entries/);
+				if (entryMatch && entryMatch[1]) {
+					entriesCreated = parseInt(entryMatch[1], 10);
+				}
+
+				messages.push({
+					type: 'info',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleLog(...args);
+			};
+
+			console.error = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				messages.push({
+					type: 'error',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleError(...args);
+			};
+
+			console.warn = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				messages.push({
+					type: 'warn',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleWarn(...args);
+			};
+
+			try {
+				const files = {
+					arc: input.arc ? Buffer.from(input.arc, 'base64') : undefined,
+					dia: input.dia ? Buffer.from(input.dia, 'base64') : undefined,
+				};
+				await syncAllBrowserData(async () => true, files);
+
+				messages.push({
+					type: 'success',
+					message: `Browser history sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+					timestamp: new Date(),
+				});
+
+				return {
+					success: true,
+					messages,
+					entriesCreated,
+				};
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+				messages.push({
+					type: 'error',
+					message: `Sync failed: ${errorMessage}`,
+					timestamp: new Date(),
+				});
+
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: `Browser history sync failed: ${errorMessage}`,
+				});
+			} finally {
+				console.log = originalConsoleLog;
+				console.error = originalConsoleError;
+				console.warn = originalConsoleWarn;
+			}
+		}),
+	runTwitter: publicProcedure
+		.input(z.object({ files: z.array(z.string()).optional() }))
+		.mutation(async ({ input }): Promise<IntegrationResult> => {
+			const messages: LogMessage[] = [];
+			let entriesCreated = 0;
+
+			const originalConsoleLog = console.log;
+			const originalConsoleError = console.error;
+			const originalConsoleWarn = console.warn;
+
+			console.log = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				const entryMatch = message.match(/Successfully created (\d+) entries/);
+				if (entryMatch && entryMatch[1]) {
+					entriesCreated = parseInt(entryMatch[1], 10);
+				}
+
+				messages.push({
+					type: 'info',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleLog(...args);
+			};
+
+			console.error = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				messages.push({
+					type: 'error',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleError(...args);
+			};
+
+			console.warn = (...args: unknown[]) => {
+				const message = args
+					.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+					.join(' ');
+
+				messages.push({
+					type: 'warn',
+					message,
+					timestamp: new Date(),
+				});
+
+				originalConsoleWarn(...args);
+			};
+
+			try {
+				const contents = input.files?.map((f) => Buffer.from(f, 'base64').toString('utf8')) ?? [];
+				const data = contents.length > 0 ? parseBookmarkDataStrings(contents) : undefined;
+				await syncTwitterData(data);
+
+				messages.push({
+					type: 'success',
+					message: `Twitter sync completed successfully${entriesCreated > 0 ? `. Created ${entriesCreated} entries.` : '.'}`,
+					timestamp: new Date(),
+				});
+
+				return {
+					success: true,
+					messages,
+					entriesCreated,
+				};
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+				messages.push({
+					type: 'error',
+					message: `Sync failed: ${errorMessage}`,
+					timestamp: new Date(),
+				});
+
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: `Twitter sync failed: ${errorMessage}`,
+				});
+			} finally {
+				console.log = originalConsoleLog;
+				console.error = originalConsoleError;
+				console.warn = originalConsoleWarn;
+			}
+		}),
 });

--- a/src/server/db/connections/arc-sqlite.ts
+++ b/src/server/db/connections/arc-sqlite.ts
@@ -1,6 +1,5 @@
-import { copyFileSync } from 'fs';
-import { existsSync } from 'fs';
-import { homedir } from 'os';
+import { copyFileSync, existsSync, mkdtempSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -22,6 +21,19 @@ export const createArcConnection = () => {
 
 	const client = createClient({
 		url: connectionUrl,
+		intMode: 'bigint',
+	});
+
+	return drizzle(client, { schema });
+};
+
+export const createArcConnectionFromBuffer = (buffer: Buffer) => {
+	const tempDir = mkdtempSync(join(tmpdir(), 'arc-history-'));
+	const tempPath = join(tempDir, 'History');
+	writeFileSync(tempPath, buffer);
+
+	const client = createClient({
+		url: `file:${tempPath}`,
 		intMode: 'bigint',
 	});
 

--- a/src/server/db/connections/dia-sqlite.ts
+++ b/src/server/db/connections/dia-sqlite.ts
@@ -1,6 +1,5 @@
-import { copyFileSync } from 'fs';
-import { existsSync } from 'fs';
-import { homedir } from 'os';
+import { copyFileSync, existsSync, mkdtempSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -22,6 +21,19 @@ export const createDiaConnection = () => {
 
 	const client = createClient({
 		url: connectionUrl,
+		intMode: 'bigint',
+	});
+
+	return drizzle(client, { schema });
+};
+
+export const createDiaConnectionFromBuffer = (buffer: Buffer) => {
+	const tempDir = mkdtempSync(join(tmpdir(), 'dia-history-'));
+	const tempPath = join(tempDir, 'History');
+	writeFileSync(tempPath, buffer);
+
+	const client = createClient({
+		url: `file:${tempPath}`,
 		intMode: 'bigint',
 	});
 

--- a/src/server/db/connections/index.ts
+++ b/src/server/db/connections/index.ts
@@ -1,1 +1,3 @@
 export * from './postgres';
+export { createArcConnection, createArcConnectionFromBuffer } from './arc-sqlite';
+export { createDiaConnection, createDiaConnectionFromBuffer } from './dia-sqlite';

--- a/src/server/integrations/twitter/sync.ts
+++ b/src/server/integrations/twitter/sync.ts
@@ -172,10 +172,15 @@ export async function loadBookmarksData(): Promise<{
  * @returns The number of successfully processed tweets
  * @throws Error if processing fails
  */
-async function syncTwitterBookmarks(integrationRunId: number): Promise<number> {
+async function syncTwitterBookmarks(
+	integrationRunId: number,
+	uploadedData?: TwitterBookmarksArray
+): Promise<number> {
 	try {
 		// Step 1: Load bookmarks data
-		const { data: bookmarkResponses, processedFiles } = await loadBookmarksData();
+		const { data: bookmarkResponses, processedFiles } = uploadedData
+			? { data: uploadedData, processedFiles: [] }
+			: await loadBookmarksData();
 		if (bookmarkResponses.length === 0) {
 			logger.info('No Twitter bookmarks data found');
 			return 0;
@@ -394,15 +399,28 @@ async function createRelatedRecords(): Promise<void> {
 /**
  * Orchestrates the Twitter data synchronization process
  */
-async function syncTwitterData(): Promise<void> {
+async function syncTwitterData(data?: TwitterBookmarksArray): Promise<void> {
 	try {
 		logger.start('Starting Twitter data synchronization');
-		await runIntegration('twitter', syncTwitterBookmarks);
+		await runIntegration('twitter', (id) => syncTwitterBookmarks(id, data));
 		logger.complete('Twitter data synchronization completed');
 	} catch (error) {
 		logger.error('Error syncing Twitter data', error);
 		throw error;
 	}
+}
+
+export function parseBookmarkDataStrings(strings: string[]): TwitterBookmarksArray {
+	const combined: TwitterBookmarksArray = [];
+	for (const content of strings) {
+		const rawData = JSON.parse(content);
+		const result = TwitterBookmarksArraySchema.safeParse(rawData);
+		if (!result.success) {
+			throw new Error('Invalid Twitter bookmarks data');
+		}
+		combined.push(...result.data);
+	}
+	return combined;
 }
 
 export { syncTwitterData };


### PR DESCRIPTION
## Summary
- allow user-uploaded files for browser history and Twitter integrations
- refactor connection utilities to create SQLite connections from buffers
- extend tRPC mutations to accept base64-encoded data
- add file inputs on integrations page for browser history and Twitter

## Testing
- `pnpm lint`
- `pnpm tsc`


------
https://chatgpt.com/codex/tasks/task_e_688b3286cf708322aecf9e25dd97d15a