### PR TITLE
Add GitHub OAuth authentication and admin authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ DATABASE_URL_DEV="postgresql://username:password@localhost:5432/redcliffrecord-d
 PUBLIC_URL="http[s]://[tailscale-hostname-or-localhost]:[port]"
 PUBLIC_DEV_PORT="5173" # Only for dev server
 
+# Authentication (Optional — when absent, auth is disabled and all requests are admin)
+# GitHub OAuth App credentials — create at: https://github.com/settings/developers
+ADMIN_GITHUB_ID=""           # Numeric GitHub user ID of the admin
+GITHUB_CLIENT_ID=""          # GitHub OAuth App client ID
+GITHUB_CLIENT_SECRET=""      # GitHub OAuth App client secret
+SESSION_SECRET=""            # ≥32 char random string for HMAC signing (generate: openssl rand -base64 32)
+
 # OpenAI Configuration (Required for embeddings)
 OPENAI_API_KEY="sk-..."
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,43 @@ Each integration is optional. Only configure the ones you need:
 
   Note: Currently hardcoded to the author's album. See [INTEGRATIONS.md](./INTEGRATIONS.md#adobe-lightroom-integration) for setup details.
 
+### 5. Authentication (Optional)
+
+Authentication uses GitHub OAuth to restrict mutations to a single admin user. **When auth env vars are absent, all requests are treated as admin** — no setup needed for local-only use.
+
+To enable authentication:
+
+1. Find your GitHub user ID:
+
+   ```bash
+   gh api user --jq .id
+   ```
+
+2. Create a [GitHub OAuth App](https://github.com/settings/developers) → "New OAuth App":
+   - **Homepage URL**: your app URL (e.g. `http://localhost:5173`)
+   - **Authorization callback URL**: `<your-url>/api/auth/callback`
+
+3. Generate a session secret:
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+4. Add to `.env`:
+   ```
+   ADMIN_GITHUB_ID=<your-numeric-github-id>
+   GITHUB_CLIENT_ID=<oauth-app-client-id>
+   GITHUB_CLIENT_SECRET=<oauth-app-client-secret>
+   SESSION_SECRET=<random-32+-char-string>
+   ```
+
+All four must be set for auth to activate. With auth enabled:
+
+- Read-only queries (records, search, media, links) remain public
+- All mutations require admin session
+- Browsing history and GitHub commit data require admin session
+- CLI (`rcr`) always bypasses auth
+
 ### Configure Cloudflare R2 Storage
 
 For media storage, you'll need a Cloudflare R2 bucket:
@@ -266,8 +303,6 @@ Notes:
 - Use `--` to stop option parsing when needed.
 
 ## Production Build & Deployment
-
-**⚠️ Security Warning**: This application currently has **no authentication or authorization**. If deployed publicly, anyone with the URL will have full read/write access to all data through the UI. Only deploy to production if you understand and accept this security risk, or implement authentication first.
 
 ### Build for Production
 

--- a/src/app/components/auth-button.tsx
+++ b/src/app/components/auth-button.tsx
@@ -1,0 +1,51 @@
+import { LogInIcon, LogOutIcon, ShieldIcon, ShieldOffIcon } from 'lucide-react';
+import { trpc } from '@/app/trpc';
+import { Button } from './button';
+
+export function AuthButton() {
+  const { data } = trpc.admin.session.useQuery();
+  const utils = trpc.useUtils();
+
+  // Dev-only toggle for simulating admin vs public when auth is not configured
+  if (import.meta.env.DEV && !data?.authEnabled) {
+    const isAdmin = data?.isAdmin ?? true;
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          document.cookie = isAdmin
+            ? 'rcr_dev_role=public; path=/'
+            : 'rcr_dev_role=; path=/; max-age=0';
+          void utils.invalidate();
+        }}
+        className="gap-1.5 text-xs"
+      >
+        {isAdmin ? <ShieldIcon className="size-3.5" /> : <ShieldOffIcon className="size-3.5" />}
+        {isAdmin ? 'Admin' : 'Public'}
+      </Button>
+    );
+  }
+
+  if (!data?.authEnabled) return null;
+
+  if (data.isAdmin) {
+    return (
+      <form action="/api/auth/logout" method="POST">
+        <Button type="submit" variant="ghost" size="icon">
+          <LogOutIcon className="h-5 w-5" />
+          <span className="sr-only">Sign out</span>
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <Button variant="ghost" size="icon" asChild>
+      <a href="/api/auth/github">
+        <LogInIcon className="h-5 w-5" />
+        <span className="sr-only">Sign in</span>
+      </a>
+    </Button>
+  );
+}

--- a/src/app/lib/hooks/use-record-search.ts
+++ b/src/app/lib/hooks/use-record-search.ts
@@ -11,6 +11,8 @@ interface UseRecordSearchOptions {
   textLimit?: number;
   /** Maximum vector search results (default: 5) */
   vectorLimit?: number;
+  /** Enable vector/semantic search (default: true). Disable for non-admin users. */
+  enableVectorSearch?: boolean;
 }
 
 /**
@@ -20,7 +22,13 @@ interface UseRecordSearchOptions {
  * are filtered to exclude any records already in text results.
  */
 export function useRecordSearch(query: string, options: UseRecordSearchOptions = {}) {
-  const { debounceMs = 300, minQueryLength = 1, textLimit = 10, vectorLimit = 5 } = options;
+  const {
+    debounceMs = 300,
+    minQueryLength = 1,
+    textLimit = 10,
+    vectorLimit = 5,
+    enableVectorSearch = true,
+  } = options;
 
   const debouncedQuery = useDebounce(query, debounceMs);
   const shouldSearch = debouncedQuery.length >= minQueryLength;
@@ -40,7 +48,7 @@ export function useRecordSearch(query: string, options: UseRecordSearchOptions =
   const { data: vectorResults = [], isFetching: vectorFetching } = trpc.search.byVector.useQuery(
     { query: debouncedQuery, limit: vectorLimit },
     {
-      enabled: shouldSearch,
+      enabled: shouldSearch && enableVectorSearch,
       trpc: {
         context: {
           skipBatch: true,

--- a/src/app/routeTree.gen.ts
+++ b/src/app/routeTree.gen.ts
@@ -13,6 +13,9 @@ import { Route as RecordsRouteRouteImport } from './routes/records/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecordsRecordIdRouteImport } from './routes/records/$recordId'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc/$'
+import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
+import { Route as ApiAuthGithubRouteImport } from './routes/api/auth/github'
+import { Route as ApiAuthCallbackRouteImport } from './routes/api/auth/callback'
 
 const RecordsRouteRoute = RecordsRouteRouteImport.update({
   id: '/records',
@@ -34,17 +37,38 @@ const ApiTrpcSplatRoute = ApiTrpcSplatRouteImport.update({
   path: '/api/trpc/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAuthLogoutRoute = ApiAuthLogoutRouteImport.update({
+  id: '/api/auth/logout',
+  path: '/api/auth/logout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAuthGithubRoute = ApiAuthGithubRouteImport.update({
+  id: '/api/auth/github',
+  path: '/api/auth/github',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAuthCallbackRoute = ApiAuthCallbackRouteImport.update({
+  id: '/api/auth/callback',
+  path: '/api/auth/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/records': typeof RecordsRouteRouteWithChildren
   '/records/$recordId': typeof RecordsRecordIdRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/github': typeof ApiAuthGithubRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/records': typeof RecordsRouteRouteWithChildren
   '/records/$recordId': typeof RecordsRecordIdRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/github': typeof ApiAuthGithubRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
 }
 export interface FileRoutesById {
@@ -52,19 +76,47 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/records': typeof RecordsRouteRouteWithChildren
   '/records/$recordId': typeof RecordsRecordIdRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/github': typeof ApiAuthGithubRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/records' | '/records/$recordId' | '/api/trpc/$'
+  fullPaths:
+    | '/'
+    | '/records'
+    | '/records/$recordId'
+    | '/api/auth/callback'
+    | '/api/auth/github'
+    | '/api/auth/logout'
+    | '/api/trpc/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/records' | '/records/$recordId' | '/api/trpc/$'
-  id: '__root__' | '/' | '/records' | '/records/$recordId' | '/api/trpc/$'
+  to:
+    | '/'
+    | '/records'
+    | '/records/$recordId'
+    | '/api/auth/callback'
+    | '/api/auth/github'
+    | '/api/auth/logout'
+    | '/api/trpc/$'
+  id:
+    | '__root__'
+    | '/'
+    | '/records'
+    | '/records/$recordId'
+    | '/api/auth/callback'
+    | '/api/auth/github'
+    | '/api/auth/logout'
+    | '/api/trpc/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   RecordsRouteRoute: typeof RecordsRouteRouteWithChildren
+  ApiAuthCallbackRoute: typeof ApiAuthCallbackRoute
+  ApiAuthGithubRoute: typeof ApiAuthGithubRoute
+  ApiAuthLogoutRoute: typeof ApiAuthLogoutRoute
   ApiTrpcSplatRoute: typeof ApiTrpcSplatRoute
 }
 
@@ -98,6 +150,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTrpcSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/auth/logout': {
+      id: '/api/auth/logout'
+      path: '/api/auth/logout'
+      fullPath: '/api/auth/logout'
+      preLoaderRoute: typeof ApiAuthLogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/github': {
+      id: '/api/auth/github'
+      path: '/api/auth/github'
+      fullPath: '/api/auth/github'
+      preLoaderRoute: typeof ApiAuthGithubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/callback': {
+      id: '/api/auth/callback'
+      path: '/api/auth/callback'
+      fullPath: '/api/auth/callback'
+      preLoaderRoute: typeof ApiAuthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -116,6 +189,9 @@ const RecordsRouteRouteWithChildren = RecordsRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   RecordsRouteRoute: RecordsRouteRouteWithChildren,
+  ApiAuthCallbackRoute: ApiAuthCallbackRoute,
+  ApiAuthGithubRoute: ApiAuthGithubRoute,
+  ApiAuthLogoutRoute: ApiAuthLogoutRoute,
   ApiTrpcSplatRoute: ApiTrpcSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/app/routes/-app-components/app-layout.tsx
+++ b/src/app/routes/-app-components/app-layout.tsx
@@ -1,6 +1,7 @@
 import { Link, type LinkComponentProps } from '@tanstack/react-router';
 import { MoonIcon, MountainSnowIcon, SunIcon } from 'lucide-react';
 import { type ReactNode } from 'react';
+import { AuthButton } from '@/components/auth-button';
 import { Button } from '@/components/button';
 import { KeyboardShortcutsHelp } from '@/components/keyboard-shortcuts-help';
 import { Separator } from '@/components/separator';
@@ -47,6 +48,7 @@ export const AppLayout = ({ children, currentTheme, onThemeChange }: AppLayoutPr
         <li className="flex items-center gap-2">
           <SiteSearch />
           <KeyboardShortcutsHelp />
+          <AuthButton />
           <Button variant="ghost" onClick={toggleTheme} className="h-9 w-9 p-0">
             {currentTheme === 'light' ? (
               <SunIcon className="h-5 w-5" />

--- a/src/app/routes/__root.tsx
+++ b/src/app/routes/__root.tsx
@@ -19,7 +19,13 @@ export interface RouterAppContext {
 }
 
 export const Route = createRootRouteWithContext<RouterAppContext>()({
-  loader: () => getTheme(),
+  loader: async ({ context: { trpc, queryClient } }) => {
+    const [theme] = await Promise.all([
+      getTheme(),
+      queryClient.ensureQueryData(trpc.admin.session.queryOptions()),
+    ]);
+    return theme;
+  },
   head: () => ({
     meta: [
       {

--- a/src/app/routes/api/auth/callback.ts
+++ b/src/app/routes/api/auth/callback.ts
@@ -1,0 +1,108 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createSessionCookie, isAdminUser, sessionSetCookieHeader } from '@/server/lib/auth';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+function parseCookie(header: string | null, name: string): string | undefined {
+  if (!header) return undefined;
+  return header
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+}
+
+const handle = async ({ request }: { request: Request }) => {
+  const baseUrl =
+    process.env.PUBLIC_URL ?? `http://localhost:${process.env.PUBLIC_DEV_PORT ?? '5173'}`;
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  // Validate CSRF state
+  const cookieState = parseCookie(request.headers.get('cookie'), 'oauth_state');
+  const clearStateCookie = `oauth_state=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0${isDev ? '' : '; Secure'}`;
+
+  if (!code || !state || state !== cookieState) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${baseUrl}/?auth_error=invalid_state`,
+        'Set-Cookie': clearStateCookie,
+      },
+    });
+  }
+
+  // Exchange code for access token
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  const tokenData = (await tokenRes.json()) as { access_token?: string; error?: string };
+  if (!tokenData.access_token) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${baseUrl}/?auth_error=token_exchange_failed`,
+        'Set-Cookie': clearStateCookie,
+      },
+    });
+  }
+
+  // Fetch GitHub user profile
+  const userRes = await fetch('https://api.github.com/user', {
+    headers: { Authorization: `Bearer ${tokenData.access_token}` },
+  });
+
+  const user = (await userRes.json()) as { id?: number };
+  if (!user.id) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${baseUrl}/?auth_error=user_fetch_failed`,
+        'Set-Cookie': clearStateCookie,
+      },
+    });
+  }
+
+  const githubUserId = String(user.id);
+
+  if (!isAdminUser(githubUserId)) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${baseUrl}/?auth_error=unauthorized`,
+        'Set-Cookie': clearStateCookie,
+      },
+    });
+  }
+
+  // Set session cookie and redirect home
+  const sessionCookie = createSessionCookie(githubUserId);
+  return new Response(null, {
+    status: 302,
+    headers: [
+      ['Location', `${baseUrl}/`],
+      ['Set-Cookie', clearStateCookie],
+      ['Set-Cookie', sessionSetCookieHeader(sessionCookie)],
+    ],
+  });
+};
+
+export const Route = createFileRoute('/api/auth/callback')({
+  server: {
+    handlers: {
+      GET: handle,
+    },
+  },
+});

--- a/src/app/routes/api/auth/github.ts
+++ b/src/app/routes/api/auth/github.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from 'node:crypto';
+import { createFileRoute } from '@tanstack/react-router';
+
+const handle = () => {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return new Response('OAuth not configured', { status: 500 });
+  }
+
+  const state = randomBytes(16).toString('hex');
+  const isDev = process.env.NODE_ENV !== 'production';
+
+  const redirectUri = `${process.env.PUBLIC_URL ?? `http://localhost:${process.env.PUBLIC_DEV_PORT ?? '5173'}`}/api/auth/callback`;
+
+  const url = new URL('https://github.com/login/oauth/authorize');
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('state', state);
+  url.searchParams.set('redirect_uri', redirectUri);
+  // Empty scope — only need identity, no repo access
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: url.toString(),
+      'Set-Cookie': `oauth_state=${state}; HttpOnly; SameSite=Lax; Path=/; Max-Age=600${isDev ? '' : '; Secure'}`,
+    },
+  });
+};
+
+export const Route = createFileRoute('/api/auth/github')({
+  server: {
+    handlers: {
+      GET: handle,
+    },
+  },
+});

--- a/src/app/routes/api/auth/logout.ts
+++ b/src/app/routes/api/auth/logout.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { sessionClearCookieHeader } from '@/server/lib/auth';
+
+const handle = () => {
+  const baseUrl =
+    process.env.PUBLIC_URL ?? `http://localhost:${process.env.PUBLIC_DEV_PORT ?? '5173'}`;
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${baseUrl}/`,
+      'Set-Cookie': sessionClearCookieHeader(),
+    },
+  });
+};
+
+export const Route = createFileRoute('/api/auth/logout')({
+  server: {
+    handlers: {
+      POST: handle,
+    },
+  },
+});

--- a/src/app/routes/records/$recordId.tsx
+++ b/src/app/routes/records/$recordId.tsx
@@ -190,6 +190,8 @@ function RouteComponent() {
   );
   const { recordId } = Route.useParams();
   const { data: tree, isError: treeError, isLoading: treeLoading } = useRecordTree(recordId);
+  const { data: session } = trpc.admin.session.useQuery();
+  const isAdmin = session?.isAdmin ?? false;
   const bulkUpdate = useBulkUpdate();
   const deleteMutation = useDeleteRecords();
 
@@ -349,7 +351,7 @@ function RouteComponent() {
               node.isStructural ? 'card shrink-0 last:mb-8' : 'card-compact shrink-0 last:mb-8'
             }
           >
-            {node.id === recordId ? (
+            {node.id === recordId && isAdmin ? (
               <RecordForm
                 recordId={node.id}
                 onFinalize={handleFinalize}
@@ -367,8 +369,8 @@ function RouteComponent() {
         ))}
       </ul>
       <div className="flex max-w-160 min-w-100 flex-1 flex-col gap-4 overflow-y-auto bg-c-container p-4">
-        <RelationsList id={recordId} />
-        <SimilarRecords id={recordId} />
+        <RelationsList id={recordId} isAdmin={isAdmin} />
+        <SimilarRecords id={recordId} isAdmin={isAdmin} />
       </div>
     </div>
   );

--- a/src/app/routes/records/-components/record-lookup.tsx
+++ b/src/app/routes/records/-components/record-lookup.tsx
@@ -56,6 +56,8 @@ interface RecordSearchProps {
 function RecordSearch({ onSelect }: RecordSearchProps) {
   const [query, setQuery] = useState('');
   const createRecordMutation = useUpsertRecord();
+  const { data: session } = trpc.admin.session.useQuery();
+  const isAdmin = session?.isAdmin ?? false;
 
   const {
     textResults,
@@ -65,7 +67,13 @@ function RecordSearch({ onSelect }: RecordSearchProps) {
     isLoading,
     hasResults,
     shouldSearch,
-  } = useRecordSearch(query, { debounceMs: 200, minQueryLength: 1, textLimit: 5, vectorLimit: 3 });
+  } = useRecordSearch(query, {
+    debounceMs: 200,
+    minQueryLength: 1,
+    textLimit: 5,
+    vectorLimit: 3,
+    enableVectorSearch: isAdmin,
+  });
 
   return (
     <Command shouldFilter={false} loop className="w-full" defaultValue="">
@@ -94,8 +102,8 @@ function RecordSearch({ onSelect }: RecordSearchProps) {
           </CommandGroup>
         )}
 
-        {/* Similar Records (Vector Search) */}
-        {shouldSearch && (
+        {/* Similar Records (Vector Search) — admin only */}
+        {shouldSearch && isAdmin && (
           <CommandGroup heading="Similar Records">
             {vectorFetching ? (
               <CommandItem disabled className="flex items-center justify-center">

--- a/src/app/routes/records/-components/records-grid.tsx
+++ b/src/app/routes/records/-components/records-grid.tsx
@@ -92,6 +92,8 @@ const RecordRow = memo(function RecordRow({ id }: { id: DbId }) {
 });
 
 export const RecordsGrid = () => {
+  const { data: session } = trpc.admin.session.useQuery();
+  const isAdmin = session?.isAdmin ?? false;
   const { state, setFilters, setLimit, reset } = useRecordFilters();
   const { data: queue } = trpc.records.list.useQuery(
     { ...state, offset: 0 },
@@ -237,13 +239,15 @@ export const RecordsGrid = () => {
           <button type="button" onClick={reset} className="text-start hover:underline">
             Reset to Defaults
           </button>
-          <button
-            type="button"
-            onClick={() => setFilters({ isCurated: false, hasParent: false })}
-            className="text-start hover:underline"
-          >
-            Curation Queue
-          </button>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => setFilters({ isCurated: false, hasParent: false })}
+              className="text-start hover:underline"
+            >
+              Curation Queue
+            </button>
+          )}
         </div>
         <hr />
         <div className="flex flex-col gap-1.5">
@@ -419,27 +423,29 @@ export const RecordsGrid = () => {
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="private">Is Private?</Label>
-          <ToggleGroup
-            id="private"
-            type="single"
-            value={filterValues.privateValue}
-            onValueChange={handlePrivateChange}
-            variant="outline"
-            className="w-full"
-          >
-            <ToggleGroupItem value="All" className="flex-1">
-              All
-            </ToggleGroupItem>
-            <ToggleGroupItem value="Yes" className="flex-1">
-              Yes
-            </ToggleGroupItem>
-            <ToggleGroupItem value="No" className="flex-1">
-              No
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </div>
+        {isAdmin && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="private">Is Private?</Label>
+            <ToggleGroup
+              id="private"
+              type="single"
+              value={filterValues.privateValue}
+              onValueChange={handlePrivateChange}
+              variant="outline"
+              className="w-full"
+            >
+              <ToggleGroupItem value="All" className="flex-1">
+                All
+              </ToggleGroupItem>
+              <ToggleGroupItem value="Yes" className="flex-1">
+                Yes
+              </ToggleGroupItem>
+              <ToggleGroupItem value="No" className="flex-1">
+                No
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        )}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="limit">Results Limit</Label>
           <Input
@@ -454,6 +460,7 @@ export const RecordsGrid = () => {
       </div>
     ),
     [
+      isAdmin,
       reset,
       setFilters,
       types,

--- a/src/server/api/routers/browsing.ts
+++ b/src/server/api/routers/browsing.ts
@@ -2,7 +2,7 @@ import { browsingHistoryOmitList, BrowsingHistoryOmitListInsertSchema } from '@h
 import { inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { DateSchema } from '@/shared/types/api';
-import { createTRPCRouter, publicProcedure } from '../init';
+import { adminProcedure, createTRPCRouter } from '../init';
 
 const OverviewSchema = z.object({
   date: z.string(),
@@ -283,7 +283,7 @@ function createEmptySummary(date: string): DailySummary {
 }
 
 export const browsingRouter = createTRPCRouter({
-  dailySummary: publicProcedure
+  dailySummary: adminProcedure
     .input(z.object({ date: DateSchema }))
     .query(async ({ ctx: { db }, input: { date } }): Promise<DailySummary> => {
       const startOfDay = new Date(`${date}T00:00:00`);
@@ -325,7 +325,7 @@ export const browsingRouter = createTRPCRouter({
   /**
    * List all URL patterns in the browsing history omit list
    */
-  listOmitPatterns: publicProcedure.query(async ({ ctx: { db } }): Promise<string[]> => {
+  listOmitPatterns: adminProcedure.query(async ({ ctx: { db } }): Promise<string[]> => {
     const rows = await db.query.browsingHistoryOmitList.findMany({
       columns: { pattern: true },
       orderBy: { pattern: 'asc' },
@@ -338,7 +338,7 @@ export const browsingRouter = createTRPCRouter({
    *
    * Patterns use SQL LIKE syntax (% for wildcard, _ for single character)
    */
-  upsertOmitPattern: publicProcedure
+  upsertOmitPattern: adminProcedure
     .input(BrowsingHistoryOmitListInsertSchema)
     .mutation(async ({ ctx: { db }, input }) => {
       const now = new Date();
@@ -356,7 +356,7 @@ export const browsingRouter = createTRPCRouter({
   /**
    * Delete patterns from the browsing history omit list
    */
-  deleteOmitPatterns: publicProcedure
+  deleteOmitPatterns: adminProcedure
     .input(z.array(z.string().min(1)))
     .mutation(async ({ ctx: { db }, input }) => {
       if (input.length === 0) {

--- a/src/server/api/routers/github.ts
+++ b/src/server/api/routers/github.ts
@@ -2,7 +2,7 @@ import type { GithubCommitSelect } from '@hozo';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { DateSchema } from '@/shared/types/api';
-import { createTRPCRouter, publicProcedure } from '../init';
+import { adminProcedure, createTRPCRouter } from '../init';
 
 const CommitSummarySchema = z.object({
   id: z.string(),
@@ -48,7 +48,7 @@ export const githubRouter = createTRPCRouter({
   /**
    * Get daily commit summary
    */
-  dailySummary: publicProcedure
+  dailySummary: adminProcedure
     .input(z.object({ date: DateSchema }))
     .query(async ({ ctx: { db }, input: { date } }): Promise<DailySummary> => {
       const startOfDay = new Date(`${date}T00:00:00`);
@@ -82,7 +82,7 @@ export const githubRouter = createTRPCRouter({
   /**
    * Get a single commit by ID with full details including file changes
    */
-  getCommit: publicProcedure
+  getCommit: adminProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx: { db }, input: { id } }) => {
       const commit = await db.query.githubCommits.findFirst({

--- a/src/server/api/routers/links.ts
+++ b/src/server/api/routers/links.ts
@@ -12,7 +12,7 @@ import { eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { IdSchema, type DbId } from '@/shared/types/api';
 import type { RecordLinks, RecordLinksMap } from '@/shared/types/domain';
-import { createTRPCRouter, publicProcedure } from '../init';
+import { adminProcedure, createTRPCRouter, publicProcedure } from '../init';
 
 export const linksRouter = createTRPCRouter({
   /**
@@ -139,7 +139,7 @@ export const linksRouter = createTRPCRouter({
    *
    * Used by: Relationship creation/editing, record linking interfaces
    */
-  upsert: publicProcedure.input(LinkInsertSchema).mutation(async ({ ctx: { db }, input }) => {
+  upsert: adminProcedure.input(LinkInsertSchema).mutation(async ({ ctx: { db }, input }) => {
     /* 1 ─ lookup predicate from const */
     const predicateDef = PREDICATES[input.predicate];
 
@@ -226,7 +226,7 @@ export const linksRouter = createTRPCRouter({
    *
    * Used by: Relationship management, bulk operations, cleanup processes
    */
-  delete: publicProcedure.input(z.array(IdSchema)).mutation(async ({ ctx: { db }, input }) => {
+  delete: adminProcedure.input(z.array(IdSchema)).mutation(async ({ ctx: { db }, input }) => {
     if (input.length === 0) {
       return []; // Return empty array if input is empty
     }

--- a/src/server/api/routers/records/delete.ts
+++ b/src/server/api/routers/records/delete.ts
@@ -24,9 +24,9 @@ import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { IdSchema } from '@/shared/types/api';
-import { publicProcedure } from '../../init';
+import { adminProcedure } from '../../init';
 
-export const deleteRecords = publicProcedure
+export const deleteRecords = adminProcedure
   .input(z.array(IdSchema))
   .mutation(async ({ ctx: { db }, input }): Promise<RecordSelect[]> => {
     const recordsToDelete = await db.query.records.findMany({

--- a/src/server/api/routers/records/edit.ts
+++ b/src/server/api/routers/records/edit.ts
@@ -4,7 +4,7 @@ import { inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { IdSchema, type DbId } from '@/shared/types/api';
 import type { RecordGet } from '@/shared/types/domain';
-import { publicProcedure } from '../../init';
+import { adminProcedure } from '../../init';
 
 // Schema for bulk update data - omit fields that shouldn't be bulk-updated
 const BulkUpdateDataSchema = RecordInsertSchema.omit({
@@ -14,7 +14,7 @@ const BulkUpdateDataSchema = RecordInsertSchema.omit({
   textEmbedding: true,
 }).partial();
 
-export const upsert = publicProcedure
+export const upsert = adminProcedure
   .input(RecordInsertSchema)
   .mutation(async ({ ctx: { db, loaders }, input }): Promise<RecordGet> => {
     const [result] = await db
@@ -50,7 +50,7 @@ export const upsert = publicProcedure
     return record;
   });
 
-export const bulkUpdate = publicProcedure
+export const bulkUpdate = adminProcedure
   .input(
     z.object({
       ids: z.array(IdSchema).min(1),

--- a/src/server/api/routers/records/embed.ts
+++ b/src/server/api/routers/records/embed.ts
@@ -1,9 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { embedRecordById } from '@/server/services/embed-records';
 import { IdParamSchema } from '@/shared/types/api';
-import { publicProcedure } from '../../init';
+import { adminProcedure } from '../../init';
 
-export const embed = publicProcedure
+export const embed = adminProcedure
   .input(IdParamSchema)
   .mutation(async ({ ctx: { db }, input: { id } }) => {
     const result = await embedRecordById(id);

--- a/src/server/api/routers/records/favicon.ts
+++ b/src/server/api/routers/records/favicon.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
 import { uploadMediaToR2 } from '@/server/lib/media';
-import { publicProcedure } from '../../init';
+import { assertPublicUrl } from '@/server/lib/url-utils';
+import { adminProcedure } from '../../init';
 
-export const fetchFavicon = publicProcedure
+export const fetchFavicon = adminProcedure
   .input(
     z.object({
       url: z.url(),
@@ -10,6 +11,7 @@ export const fetchFavicon = publicProcedure
     })
   )
   .mutation(async ({ input }) => {
+    assertPublicUrl(input.url);
     const domain = new URL(input.url).hostname;
     const faviconUrl = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=${input.size}`;
     const r2Url = await uploadMediaToR2(faviconUrl);

--- a/src/server/api/routers/records/list.ts
+++ b/src/server/api/routers/records/list.ts
@@ -24,7 +24,7 @@ function buildTitleFilter(
 
 export const list = publicProcedure
   .input(ListRecordsInputSchema)
-  .query(async ({ ctx: { db }, input }): Promise<IdParamList> => {
+  .query(async ({ ctx: { db, isAdmin }, input }): Promise<IdParamList> => {
     const {
       filters: {
         types,
@@ -35,7 +35,7 @@ export const list = publicProcedure
         hasTitle,
         minRating,
         maxRating,
-        isPrivate,
+        isPrivate: isPrivateFilter,
         isCurated,
         hasReminder,
         hasEmbedding,
@@ -80,7 +80,7 @@ export const list = publicProcedure
                   ilike: `%${domain}%`,
                 }
               : undefined,
-        isPrivate,
+        isPrivate: isAdmin ? isPrivateFilter : false,
         isCurated,
         ...(hasParent === true
           ? {

--- a/src/server/api/routers/records/merge.ts
+++ b/src/server/api/routers/records/merge.ts
@@ -24,7 +24,7 @@ import { eq, getTableName, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { mergeRecords } from '@/shared/lib/merge-records';
 import type { DbId } from '@/shared/types/api';
-import { publicProcedure } from '../../init';
+import { adminProcedure } from '../../init';
 
 /** Integration tables whose `recordId` may be reassigned during a merge. */
 export const integrationTableMap = {
@@ -59,7 +59,7 @@ export type MergeSnapshot = {
   }>;
 };
 
-export const merge = publicProcedure
+export const merge = adminProcedure
   .input(
     z.object({
       sourceId: z.number().int().positive(),

--- a/src/server/api/routers/records/tree.ts
+++ b/src/server/api/routers/records/tree.ts
@@ -5,10 +5,11 @@ import { publicProcedure } from '../../init';
 
 export const getFamilyTree = publicProcedure
   .input(IdParamSchema)
-  .query(async ({ ctx: { db }, input: { id } }) => {
+  .query(async ({ ctx: { db, isAdmin }, input: { id } }) => {
     const family = await db.query.records.findFirst({
       where: {
         id,
+        ...(isAdmin ? {} : { isPrivate: false }),
       },
       columns: {
         id: true,

--- a/src/server/api/routers/records/undo-merge.ts
+++ b/src/server/api/routers/records/undo-merge.ts
@@ -9,7 +9,7 @@ import {
 import { TRPCError } from '@trpc/server';
 import { eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
-import { publicProcedure } from '../../init';
+import { adminProcedure } from '../../init';
 import { type IntegrationTableName, integrationTableMap } from './merge';
 
 const IntegrationTableNameSchema = z.enum(
@@ -40,7 +40,7 @@ const MergeSnapshotSchema = z.object({
   ),
 });
 
-export const undoMerge = publicProcedure
+export const undoMerge = adminProcedure
   .input(z.object({ snapshot: MergeSnapshotSchema }))
   .mutation(async ({ ctx: { db }, input: { snapshot } }) => {
     const { sourceRecord, targetRecord } = snapshot;

--- a/src/server/cli/rcr/lib/caller.ts
+++ b/src/server/cli/rcr/lib/caller.ts
@@ -22,6 +22,7 @@ export function createCLICaller() {
   // Create a minimal context for CLI usage (no real HTTP headers needed)
   const ctx = createTRPCContext({
     headers: new Headers(),
+    isAdmin: true,
   });
 
   return createCaller(ctx);

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -1,0 +1,88 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const COOKIE_NAME = 'rcr_session';
+const MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+function getSecret(): string | undefined {
+  return process.env.SESSION_SECRET;
+}
+
+function sign(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+/** Build a signed session cookie value: `userId.iat.exp.signature` */
+export function createSessionCookie(githubUserId: string): string {
+  const secret = getSecret();
+  if (!secret) throw new Error('SESSION_SECRET is not configured');
+
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + MAX_AGE_SECONDS;
+  const payload = `${githubUserId}.${iat}.${exp}`;
+  const sig = sign(payload, secret);
+  return `${payload}.${sig}`;
+}
+
+/** Parse and validate the `rcr_session` cookie. Returns GitHub user ID or null. */
+export function parseSessionCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+
+  const secret = getSecret();
+  if (!secret) return null;
+
+  const match = cookieHeader
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return null;
+
+  const value = match.slice(COOKIE_NAME.length + 1);
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+
+  const [userId, iatStr, expStr, sig] = parts as [string, string, string, string];
+  const payload = `${userId}.${iatStr}.${expStr}`;
+
+  // Timing-safe signature comparison
+  const expected = sign(payload, secret);
+  const sigBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) return null;
+
+  // Check expiry
+  const exp = Number(expStr);
+  if (Number.isNaN(exp) || Math.floor(Date.now() / 1000) > exp) return null;
+
+  return userId;
+}
+
+export function isAdminUser(githubUserId: string): boolean {
+  return process.env.ADMIN_GITHUB_ID === githubUserId;
+}
+
+/** Whether auth is fully configured (all required env vars present). */
+export function isAuthConfigured(): boolean {
+  return !!(
+    process.env.SESSION_SECRET &&
+    process.env.ADMIN_GITHUB_ID &&
+    process.env.GITHUB_CLIENT_ID &&
+    process.env.GITHUB_CLIENT_SECRET
+  );
+}
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+export function sessionSetCookieHeader(value: string): string {
+  return `${COOKIE_NAME}=${value}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${MAX_AGE_SECONDS}${isDev ? '' : '; Secure'}`;
+}
+
+export function sessionClearCookieHeader(): string {
+  return `${COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0${isDev ? '' : '; Secure'}`;
+}
+
+/** Read a single cookie value by name from a Cookie header string. */
+export function getCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  const match = header.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match?.[1] ?? null;
+}

--- a/src/server/lib/media.ts
+++ b/src/server/lib/media.ts
@@ -3,7 +3,7 @@ import { S3Client } from 'bun';
 import mime from 'mime-types';
 import type { MediaMetadata } from '@/shared/types/media';
 import { getImageMetadata } from './image-metadata';
-import { validateAndFormatUrl } from './url-utils';
+import { assertPublicUrl, validateAndFormatUrl } from './url-utils';
 
 /* ---------------------------------------------------------------------------
  * Constants & Defaults
@@ -120,6 +120,8 @@ export async function getSmartMetadata(url: string): Promise<MediaMetadata> {
       throw new Error(`Invalid URL: ${url}`);
     }
 
+    assertPublicUrl(validatedUrl);
+
     // Start with a HEAD request to get basic info without downloading the entire file
     const headResponse = await fetch(validatedUrl, { method: 'HEAD' });
     let mediaType: MediaType = DEFAULT_MEDIA_TYPE;
@@ -186,6 +188,8 @@ export async function uploadMediaToR2(mediaUrl: string): Promise<string> {
     console.log(`Media URL already on R2: ${mediaUrl}`);
     return mediaUrl;
   }
+
+  assertPublicUrl(mediaUrl);
 
   const startTime = Date.now();
   console.log(`[Media Upload] Starting download: ${mediaUrl}`);

--- a/src/server/lib/rate-limit.ts
+++ b/src/server/lib/rate-limit.ts
@@ -1,0 +1,45 @@
+import { TRPCError } from '@trpc/server';
+
+interface RateLimiterOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+/**
+ * In-memory sliding-window rate limiter.
+ * Returns a `check(key)` function that throws TRPCError (TOO_MANY_REQUESTS) if limit exceeded.
+ */
+export function createRateLimiter({ windowMs, maxRequests }: RateLimiterOptions) {
+  const windows = new Map<string, number[]>();
+
+  // Periodic cleanup to prevent memory leaks from stale keys
+  const cleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [key, timestamps] of windows) {
+      const filtered = timestamps.filter((t) => now - t < windowMs);
+      if (filtered.length === 0) {
+        windows.delete(key);
+      } else {
+        windows.set(key, filtered);
+      }
+    }
+  }, windowMs);
+
+  // Don't block process exit
+  cleanup.unref();
+
+  return function check(key: string): void {
+    const now = Date.now();
+    const timestamps = (windows.get(key) ?? []).filter((t) => now - t < windowMs);
+
+    if (timestamps.length >= maxRequests) {
+      throw new TRPCError({
+        code: 'TOO_MANY_REQUESTS',
+        message: `Rate limit exceeded. Try again in ${Math.ceil(windowMs / 1000)}s.`,
+      });
+    }
+
+    timestamps.push(now);
+    windows.set(key, timestamps);
+  };
+}

--- a/src/shared/lib/env.ts
+++ b/src/shared/lib/env.ts
@@ -26,6 +26,12 @@ export const ServerEnvSchema = z.object({
   S3_BUCKET: z.string(),
   ASSETS_DOMAIN: z.string(),
 
+  // Authentication (all optional — when absent, auth is disabled and all requests are admin)
+  ADMIN_GITHUB_ID: z.string().optional(),
+  GITHUB_CLIENT_ID: z.string().optional(),
+  GITHUB_CLIENT_SECRET: z.string().optional(),
+  SESSION_SECRET: z.string().min(32).optional(),
+
   // External Services
   AIRTABLE_BASE_ID: z.string(),
   AIRTABLE_ACCESS_TOKEN: z.string(),


### PR DESCRIPTION
## Summary

- Adds single-user GitHub OAuth authentication with HMAC-signed httpOnly session cookies
- Gates all mutations and sensitive queries behind admin-only tRPC procedures
- Filters private records from all public queries (records, search, media)
- Gates vector/semantic search behind admin auth (costs OpenAI per embedding query)
- Hides admin-only UI elements (record editing, link management, create buttons, admin filters) for non-authenticated users
- Adds dev-only toggle in header to simulate admin vs public views without OAuth setup
- CLI bypass (`isAdmin: true`) preserves existing workflow
- When auth env vars are missing, all requests are treated as admin (backwards-compatible)

## New files

- `src/server/lib/auth.ts` — session cookie + auth utilities
- `src/server/lib/rate-limit.ts` — IP-based rate limiter
- `src/app/components/auth-button.tsx` — login/logout button + dev toggle
- `src/app/routes/api/auth/{github,callback,logout}.ts` — OAuth route handlers

## Test plan

- [ ] Without auth env vars: app works identically to before (all admin)
- [ ] Dev toggle: click Admin/Public in header to switch views, verify UI changes
- [ ] Public view: record form hidden, relations read-only, no create/delete/merge buttons, no private filter
- [ ] With auth env vars: OAuth flow works, session persists across page loads
- [ ] CLI: `rcr` commands work without auth configuration
- [ ] Private records hidden from public queries
- [ ] Vector search returns UNAUTHORIZED for non-admin