### PR TITLE
Migrate shared components to panda css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "bun run stylegen",
     "rcr": "bun src/server/cli/rcr/index.ts",
     "start": "bun run server.ts",
-    "stylegen": "panda codegen && panda cssgen",
+    "stylegen": "rm -rf src/app/styled-system && panda codegen && panda cssgen",
     "typecheck": "tsgo --noEmit",
     "typecheck:watch": "tsgo --noEmit --watch"
   },

--- a/src/app/components/external-link.tsx
+++ b/src/app/components/external-link.tsx
@@ -1,23 +1,41 @@
 import { ExternalLinkIcon } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { styled } from '@/styled-system/jsx';
+import type { ComponentProps } from '@/styled-system/types';
+
+const Anchor = styled(
+  'a',
+  {
+    base: {
+      _childIcon: {
+        transitionProperty: '[opacity]',
+        transitionDuration: '150',
+        transitionTimingFunction: 'easeOut.quad',
+        opacity: '50%',
+      },
+      _hover: {
+        _childIcon: {
+          opacity: '100%',
+        },
+      },
+    },
+  },
+  {
+    defaultProps: {
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+  }
+);
 
 export const ExternalLink = ({
   href,
   children = 'Open',
-  className,
   ...props
-}: { href: string; children?: React.ReactNode } & React.ComponentProps<'a'>) => {
+}: ComponentProps<typeof styled.a>) => {
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={children ? undefined : 'Open in new tab'}
-      className={cn('group', className)}
-      {...props}
-    >
+    <Anchor href={href} aria-label={children ? undefined : 'Open in new tab'} {...props}>
       {children}
-      <ExternalLinkIcon className="opacity-50 group-hover:opacity-100" />
-    </a>
+      <ExternalLinkIcon />
+    </Anchor>
   );
 };

--- a/src/app/components/integration-logo.tsx
+++ b/src/app/components/integration-logo.tsx
@@ -1,6 +1,8 @@
 import type { IntegrationType } from '@hozo/schema/operations';
 import { memo } from 'react';
 import { assertNever } from '@/shared/lib/type-utils';
+import { styled } from '@/styled-system/jsx';
+import type { ComponentProps } from '@/styled-system/types';
 import { AdobeLogo } from './logos/adobe';
 import { AirtableLogo } from './logos/airtable';
 import { ArcLogo } from './logos/arc';
@@ -10,33 +12,33 @@ import { ReadwiseLogo } from './logos/readwise';
 import { XLogo } from './logos/x';
 import { Tooltip } from './tooltip';
 
-interface IntegrationLogoProps {
+const LogoWrapper = styled('div', {
+  base: {
+    display: 'inline-grid',
+    placeItems: 'center',
+  },
+});
+
+interface IntegrationLogoProps extends ComponentProps<typeof LogoWrapper> {
   integration: IntegrationType;
-  className?: string;
 }
 
-const LogoComponent = ({
-  service,
-  className,
-}: {
-  service: IntegrationType;
-  className?: string;
-}) => {
+const LogoComponent = ({ service }: { service: IntegrationType }) => {
   switch (service) {
     case 'lightroom':
-      return <AdobeLogo className={className} />;
+      return <AdobeLogo />;
     case 'airtable':
-      return <AirtableLogo className={className} />;
+      return <AirtableLogo />;
     case 'browser_history':
-      return <ArcLogo className={className} />;
+      return <ArcLogo />;
     case 'github':
-      return <GithubLogo className={className} />;
+      return <GithubLogo />;
     case 'raindrop':
-      return <RaindropLogo className={className} />;
+      return <RaindropLogo />;
     case 'readwise':
-      return <ReadwiseLogo className={className} />;
+      return <ReadwiseLogo />;
     case 'twitter':
-      return <XLogo className={className} />;
+      return <XLogo />;
     case 'ai_chat':
     case 'crawler':
     case 'embeddings':
@@ -50,18 +52,16 @@ const LogoComponent = ({
 
 export const IntegrationLogo = memo(function IntegrationLogo({
   integration: service,
-  className,
+  ...props
 }: IntegrationLogoProps) {
   return (
     <Tooltip.Root>
-      <Tooltip.Trigger asChild css={{ display: 'inline-grid', placeItems: 'center' }}>
-        <div className={className}>
+      <Tooltip.Trigger asChild>
+        <LogoWrapper {...props}>
           <LogoComponent service={service} />
-        </div>
+        </LogoWrapper>
       </Tooltip.Trigger>
-      <Tooltip.Content>
-        <span className="capitalize">{service}</span>
-      </Tooltip.Content>
+      <Tooltip.Content css={{ textTransform: 'capitalize' }}>{service}</Tooltip.Content>
     </Tooltip.Root>
   );
 });

--- a/src/app/components/integration-logo.tsx
+++ b/src/app/components/integration-logo.tsx
@@ -56,11 +56,13 @@ export const IntegrationLogo = memo(function IntegrationLogo({
 }: IntegrationLogoProps) {
   return (
     <Tooltip.Root>
-      <Tooltip.Trigger asChild>
-        <LogoWrapper {...props}>
-          <LogoComponent service={service} />
-        </LogoWrapper>
-      </Tooltip.Trigger>
+      <Tooltip.Trigger
+        render={
+          <LogoWrapper {...props}>
+            <LogoComponent service={service} />
+          </LogoWrapper>
+        }
+      />
       <Tooltip.Content css={{ textTransform: 'capitalize' }}>{service}</Tooltip.Content>
     </Tooltip.Root>
   );

--- a/src/app/components/tooltip/tooltip.recipe.ts
+++ b/src/app/components/tooltip/tooltip.recipe.ts
@@ -2,13 +2,17 @@ import { defineSlotRecipe } from '@/app/styles/define-recipe';
 
 export const tooltipRecipe = defineSlotRecipe({
   className: 'tooltip',
-  slots: ['root', 'trigger', 'portal', 'content', 'arrow'],
+  slots: ['positioner', 'popup', 'arrow'],
   base: {
-    content: {
+    positioner: {
+      isolation: 'isolate',
+      zIndex: '50',
+    },
+    popup: {
       zIndex: '50',
       width: '[fit-content]',
       maxWidth: '[50vw]',
-      transformOrigin: 'var(--radix-tooltip-content-transform-origin)',
+      transformOrigin: 'var(--transform-origin)',
       borderRadius: 'md',
       backgroundColor: 'float',
       mode: 'dark',
@@ -20,28 +24,60 @@ export const tooltipRecipe = defineSlotRecipe({
       _dark: {
         border: 'divider',
       },
-      animateIn: true,
-      fadeIn: 0,
-      zoomIn: 0.95,
-      _closed: { animateOut: true, fadeOut: 0, zoomOut: 0.95 },
+      _open: {
+        animateIn: true,
+        fadeIn: 0,
+        zoomIn: 0.95,
+      },
+      _closed: {
+        animateOut: true,
+        fadeOut: 0,
+        zoomOut: 0.95,
+      },
       '&[data-side=bottom]': { slideInY: '-0.5rem' },
       '&[data-side=top]': { slideInY: '0.5rem' },
-      '&[data-side=left]': { slideInX: '-0.5rem' },
-      '&[data-side=right]': { slideInX: '0.5rem' },
+      '&[data-side=left]': { slideInX: '0.5rem' },
+      '&[data-side=right]': { slideInX: '-0.5rem' },
+      '&[data-side=inline-start]': { slideInX: '0.5rem' },
+      '&[data-side=inline-end]': { slideInX: '-0.5rem' },
     },
     arrow: {
-      zIndex: '50',
       boxSize: '2.5',
-      translateCenter: 'y',
+      translate: '[0 calc(-50% - 2px)]',
       rotate: '[45deg]',
-      borderRadius: 'sm',
+      borderRadius: '[2px]',
       backgroundColor: 'float',
-      fill: 'float',
       _dark: {
         borderColor: 'border',
         borderStyle: 'solid',
         borderBlockEndWidth: '1px',
         borderInlineEndWidth: '1px',
+      },
+      '&[data-side=bottom]': {
+        insetBlockStart: '1',
+      },
+      '&[data-side=top]': {
+        insetBlockEnd: '-2.5',
+      },
+      '&[data-side=left]': {
+        insetBlockStart: '[50% !important]',
+        insetInlineEnd: '-1',
+        translate: '[0 -50%]',
+      },
+      '&[data-side=right]': {
+        insetBlockStart: '[50% !important]',
+        insetInlineStart: '-1',
+        translate: '[0 -50%]',
+      },
+      '&[data-side=inline-end]': {
+        insetBlockStart: '[50% !important]',
+        insetInlineStart: '-1',
+        translate: '[0 -50%]',
+      },
+      '&[data-side=inline-start]': {
+        insetBlockStart: '[50% !important]',
+        insetInlineEnd: '-1',
+        translate: '[0 -50%]',
       },
     },
   },

--- a/src/app/components/tooltip/tooltip.tsx
+++ b/src/app/components/tooltip/tooltip.tsx
@@ -36,7 +36,7 @@ export const Content = ({
   sideOffset = 0,
   children,
   ...props
-}: ComponentProps<typeof Tooltip.Content>) => {
+}: ComponentProps<typeof StyledContent>) => {
   return (
     <Portal>
       <StyledContent sideOffset={sideOffset} {...props}>

--- a/src/app/components/tooltip/tooltip.tsx
+++ b/src/app/components/tooltip/tooltip.tsx
@@ -1,48 +1,85 @@
-import { Tooltip } from 'radix-ui';
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import { createStyleContext } from '@/styled-system/jsx';
 import { tooltip } from '@/styled-system/recipes';
 import type { ComponentProps } from '@/styled-system/types';
 
 const { withProvider, withContext } = createStyleContext(tooltip);
 
-export function Provider({ delayDuration = 300, ...props }: Tooltip.TooltipProviderProps) {
-  return <Tooltip.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />;
+export function Provider({ delay = 300, ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />;
 }
 
-export const Root = withProvider(Tooltip.Root, 'root', {
-  defaultProps: {
-    'data-slot': 'tooltip',
-  },
-});
-export const Trigger = withContext(Tooltip.Trigger, 'trigger', {
-  defaultProps: {
-    'data-slot': 'tooltip-trigger',
-  },
-});
-export const Portal = Tooltip.Portal;
+export function Root(props: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
 
-const StyledContent = withContext(Tooltip.Content, 'content', {
-  defaultProps: {
-    'data-slot': 'tooltip-content',
-  },
+export function Trigger(props: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+const StyledPositioner = withProvider(TooltipPrimitive.Positioner, 'positioner', {
+  defaultProps: { 'data-slot': 'tooltip-positioner' },
 });
-const StyledArrow = withContext(Tooltip.Arrow, 'arrow', {
-  defaultProps: {
-    'data-slot': 'tooltip-arrow',
-  },
+const StyledPopup = withContext(TooltipPrimitive.Popup, 'popup', {
+  defaultProps: { 'data-slot': 'tooltip-content' },
+});
+const StyledArrow = withContext(TooltipPrimitive.Arrow, 'arrow', {
+  defaultProps: { 'data-slot': 'tooltip-arrow' },
 });
 
-export const Content = ({
-  sideOffset = 0,
+type PositionerProps = Pick<
+  TooltipPrimitive.Positioner.Props,
+  | 'anchor'
+  | 'positionMethod'
+  | 'side'
+  | 'sideOffset'
+  | 'align'
+  | 'alignOffset'
+  | 'collisionBoundary'
+  | 'collisionPadding'
+  | 'sticky'
+  | 'arrowPadding'
+  | 'disableAnchorTracking'
+  | 'collisionAvoidance'
+>;
+
+export function Content({
+  anchor,
+  positionMethod,
+  side,
+  sideOffset = 8,
+  align,
+  alignOffset,
+  collisionBoundary,
+  collisionPadding,
+  sticky,
+  arrowPadding,
+  disableAnchorTracking,
+  collisionAvoidance,
   children,
   ...props
-}: ComponentProps<typeof StyledContent>) => {
+}: ComponentProps<typeof StyledPopup> & PositionerProps) {
   return (
-    <Portal>
-      <StyledContent sideOffset={sideOffset} {...props}>
-        {children}
-        <StyledArrow />
-      </StyledContent>
-    </Portal>
+    <TooltipPrimitive.Portal>
+      <StyledPositioner
+        anchor={anchor}
+        positionMethod={positionMethod}
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        sticky={sticky}
+        arrowPadding={arrowPadding}
+        disableAnchorTracking={disableAnchorTracking}
+        collisionAvoidance={collisionAvoidance}
+      >
+        <StyledPopup {...props}>
+          {children}
+          <StyledArrow />
+        </StyledPopup>
+      </StyledPositioner>
+    </TooltipPrimitive.Portal>
   );
-};
+}

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -375,30 +375,32 @@ export function RecordForm({
                   const { icon: Icon, description } = recordTypeIcons[type];
                   return (
                     <Tooltip.Root key={type}>
-                      <Tooltip.Trigger asChild>
-                        <ToggleGroupItem
-                          value={type}
-                          aria-label={type}
-                          data-state={field.state.value === type ? 'on' : 'off'}
-                          className={css({
-                            display: 'flex',
-                            flexGrow: '1',
-                            alignItems: 'center',
-                            gap: '1',
-                          })}
-                        >
-                          <Icon />
-                          <styled.span
-                            css={{
-                              display: 'none',
-                              textTransform: 'capitalize',
-                              '@container (min-width: 30rem)': { display: 'inline' },
-                            }}
+                      <Tooltip.Trigger
+                        render={
+                          <ToggleGroupItem
+                            value={type}
+                            aria-label={type}
+                            data-state={field.state.value === type ? 'on' : 'off'}
+                            className={css({
+                              display: 'flex',
+                              flexGrow: '1',
+                              alignItems: 'center',
+                              gap: '1',
+                            })}
                           >
-                            {type}
-                          </styled.span>
-                        </ToggleGroupItem>
-                      </Tooltip.Trigger>
+                            <Icon />
+                            <styled.span
+                              css={{
+                                display: 'none',
+                                textTransform: 'capitalize',
+                                '@container (min-width: 30rem)': { display: 'inline' },
+                              }}
+                            >
+                              {type}
+                            </styled.span>
+                          </ToggleGroupItem>
+                        }
+                      />
                       <Tooltip.Content side="bottom">
                         <p>
                           <styled.strong
@@ -418,22 +420,24 @@ export function RecordForm({
           <form.Field name="isCurated">
             {(field) => (
               <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <styled.span css={{ display: 'inline-flex' }}>
-                    <Toggle
-                      variant="outline"
-                      pressed={field.state.value}
-                      aria-label={field.state.value ? 'Curated' : 'Not curated'}
-                      onPressedChange={(pressed) => {
-                        field.handleChange(pressed);
-                        debouncedSave();
-                      }}
-                      disabled={isFormLoading}
-                    >
-                      {field.state.value ? <BadgeCheckIcon /> : <BadgeIcon />}
-                    </Toggle>
-                  </styled.span>
-                </Tooltip.Trigger>
+                <Tooltip.Trigger
+                  render={
+                    <styled.span css={{ display: 'inline-flex' }}>
+                      <Toggle
+                        variant="outline"
+                        pressed={field.state.value}
+                        aria-label={field.state.value ? 'Curated' : 'Not curated'}
+                        onPressedChange={(pressed) => {
+                          field.handleChange(pressed);
+                          debouncedSave();
+                        }}
+                        disabled={isFormLoading}
+                      >
+                        {field.state.value ? <BadgeCheckIcon /> : <BadgeIcon />}
+                      </Toggle>
+                    </styled.span>
+                  }
+                />
                 <Tooltip.Content>{field.state.value ? 'Curated' : 'Not curated'}</Tooltip.Content>
               </Tooltip.Root>
             )}
@@ -441,22 +445,24 @@ export function RecordForm({
           <form.Field name="isPrivate">
             {(field) => (
               <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <styled.span css={{ display: 'inline-flex' }}>
-                    <Toggle
-                      variant="outline"
-                      pressed={field.state.value}
-                      aria-label={field.state.value ? 'Private' : 'Public'}
-                      onPressedChange={(pressed) => {
-                        field.handleChange(pressed);
-                        debouncedSave();
-                      }}
-                      disabled={isFormLoading}
-                    >
-                      {field.state.value ? <EyeOffIcon /> : <EyeIcon />}
-                    </Toggle>
-                  </styled.span>
-                </Tooltip.Trigger>
+                <Tooltip.Trigger
+                  render={
+                    <styled.span css={{ display: 'inline-flex' }}>
+                      <Toggle
+                        variant="outline"
+                        pressed={field.state.value}
+                        aria-label={field.state.value ? 'Private' : 'Public'}
+                        onPressedChange={(pressed) => {
+                          field.handleChange(pressed);
+                          debouncedSave();
+                        }}
+                        disabled={isFormLoading}
+                      >
+                        {field.state.value ? <EyeOffIcon /> : <EyeIcon />}
+                      </Toggle>
+                    </styled.span>
+                  }
+                />
                 <Tooltip.Content>{field.state.value ? 'Private' : 'Public'}</Tooltip.Content>
               </Tooltip.Root>
             )}

--- a/src/app/routes/records/-components/record-metabar.tsx
+++ b/src/app/routes/records/-components/record-metabar.tsx
@@ -99,25 +99,27 @@ export const Metabar = ({ recordId, className, onDelete, ...props }: MetabarProp
       )}
       <styled.div css={{ display: 'flex', alignItems: 'center', gap: '0.5' }}>
         <Tooltip.Root>
-          <Tooltip.Trigger asChild>
-            <styled.span css={{ display: 'inline-flex' }}>
-              <Toggle
-                pressed={inBasket}
-                aria-label={inBasket ? 'Remove from basket' : 'Add to basket'}
-                onPressedChange={(pressed) => {
-                  if (pressed) {
-                    addToBasket(recordId);
-                    toast.success('Added to basket');
-                  } else {
-                    removeFromBasket(recordId);
-                    toast.success('Removed from basket');
-                  }
-                }}
-              >
-                <ShoppingBasketIcon />
-              </Toggle>
-            </styled.span>
-          </Tooltip.Trigger>
+          <Tooltip.Trigger
+            render={
+              <styled.span css={{ display: 'inline-flex' }}>
+                <Toggle
+                  pressed={inBasket}
+                  aria-label={inBasket ? 'Remove from basket' : 'Add to basket'}
+                  onPressedChange={(pressed) => {
+                    if (pressed) {
+                      addToBasket(recordId);
+                      toast.success('Added to basket');
+                    } else {
+                      removeFromBasket(recordId);
+                      toast.success('Removed from basket');
+                    }
+                  }}
+                >
+                  <ShoppingBasketIcon />
+                </Toggle>
+              </styled.span>
+            }
+          />
           <Tooltip.Content>{inBasket ? 'Remove from basket' : 'Add to basket'}</Tooltip.Content>
         </Tooltip.Root>
         <AlertDialog.Root>
@@ -208,18 +210,20 @@ const AvatarSection = ({ record }: { record: RecordGet }) => {
         {localUrl && <ExternalLink href={localUrl}>{null}</ExternalLink>}
       </styled.div>
       <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={!record.url || isFetchingFavicon}
-            onClick={handleFetchFavicon}
-          >
-            {isFetchingFavicon ? <Spinner /> : <GlobeIcon />}
-            Fetch favicon
-          </Button>
-        </Tooltip.Trigger>
+        <Tooltip.Trigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!record.url || isFetchingFavicon}
+              onClick={handleFetchFavicon}
+            >
+              {isFetchingFavicon ? <Spinner /> : <GlobeIcon />}
+              Fetch favicon
+            </Button>
+          }
+        />
         <Tooltip.Content>
           {record.url
             ? 'Fetch the favicon from the record URL'

--- a/src/app/routes/records/-components/record-metabar.tsx
+++ b/src/app/routes/records/-components/record-metabar.tsx
@@ -92,7 +92,7 @@ export const Metabar = ({ recordId, className, onDelete, ...props }: MetabarProp
             <IntegrationLogo
               key={source}
               integration={source}
-              className={css({ textStyle: 'xs', opacity: '50%' })}
+              css={{ textStyle: 'xs', opacity: '50%' }}
             />
           ))}
         </styled.div>

--- a/src/app/routes/records/-components/records-grid.tsx
+++ b/src/app/routes/records/-components/records-grid.tsx
@@ -74,33 +74,36 @@ function RecordRow({ recordId }: { recordId: DbId }) {
         <RecordTypeIcon type={record.type} />
       </Table.Cell>
       <Table.Cell css={{ maxWidth: '60', whiteSpace: 'nowrap', truncate: true }}>
-        <Tooltip.Root delayDuration={1000} disableHoverableContent>
-          <Tooltip.Trigger asChild>
-            <Link
-              to="/records/$recordId"
-              params={{ recordId: record.id }}
-              className={css({
-                display: 'flex',
-                width: 'full',
-                alignItems: 'center',
-                gap: '2',
-                truncate: true,
-              })}
-            >
-              <styled.span css={{ truncate: true }}>{label}</styled.span>
-              {record.abbreviation && (
-                <styled.span css={{ flexShrink: '0', color: 'muted' }}>
-                  ({record.abbreviation})
-                </styled.span>
-              )}
-              {record.sense && (
-                <styled.span css={{ flexShrink: '0', color: 'muted', fontStyle: 'italic' }}>
-                  {record.sense}
-                </styled.span>
-              )}
-              {inBasket && <ShoppingBasketIcon className={css({ color: 'accent' })} />}
-            </Link>
-          </Tooltip.Trigger>
+        <Tooltip.Root disableHoverablePopup>
+          <Tooltip.Trigger
+            delay={1000}
+            render={
+              <Link
+                to="/records/$recordId"
+                params={{ recordId: record.id }}
+                className={css({
+                  display: 'flex',
+                  width: 'full',
+                  alignItems: 'center',
+                  gap: '2',
+                  truncate: true,
+                })}
+              >
+                <styled.span css={{ truncate: true }}>{label}</styled.span>
+                {record.abbreviation && (
+                  <styled.span css={{ flexShrink: '0', color: 'muted' }}>
+                    ({record.abbreviation})
+                  </styled.span>
+                )}
+                {record.sense && (
+                  <styled.span css={{ flexShrink: '0', color: 'muted', fontStyle: 'italic' }}>
+                    {record.sense}
+                  </styled.span>
+                )}
+                {inBasket && <ShoppingBasketIcon className={css({ color: 'accent' })} />}
+              </Link>
+            }
+          />
           <Tooltip.Content className={css({ maxWidth: '96' })}>
             <styled.div css={{ lineClamp: '3' }}>{label}</styled.div>
           </Tooltip.Content>

--- a/src/app/routes/records/-components/records-grid.tsx
+++ b/src/app/routes/records/-components/records-grid.tsx
@@ -328,14 +328,7 @@ export const RecordsGrid = () => {
                         handleSourceToggle(source);
                       }}
                     >
-                      <IntegrationLogo
-                        integration={source}
-                        className={css({
-                          display: 'grid',
-                          boxSize: '4',
-                          placeItems: 'center',
-                        })}
-                      />
+                      <IntegrationLogo integration={source} css={{ boxSize: '4' }} />
                       <styled.span css={{ flex: '1', textTransform: 'capitalize' }}>
                         {source}
                       </styled.span>

--- a/src/app/routes/records/-components/type-icons.tsx
+++ b/src/app/routes/records/-components/type-icons.tsx
@@ -19,9 +19,7 @@ export const RecordTypeIcon = memo(({ type, ...props }: RecordTypeIconProps) => 
   const { icon: Icon, description } = recordTypeIcons[type];
   return (
     <Tooltip.Root>
-      <Tooltip.Trigger asChild>
-        <Icon {...props} />
-      </Tooltip.Trigger>
+      <Tooltip.Trigger render={<Icon {...props} />} />
       <Tooltip.Content>{description}</Tooltip.Content>
     </Tooltip.Root>
   );


### PR DESCRIPTION
Continues the Tailwind-to-Panda and Radix-to-Base-UI migration, and establishes the Base UI adaptation pattern for subsequent primitives.

The external-link and integration-logo components move off Tailwind utility classes onto Panda style objects. No visual changes — just `className` strings replaced with `css={{...}}` and `styled.*` elements.

Tooltip switches from `radix-ui` to `@base-ui/react/tooltip`, using shadcn's Base UI reference as the structural model:

- Recipe rewritten as a three-slot Panda `slotRecipe` (`positioner`, `popup`, `arrow`), keeping RCR design tokens (`float`, `divider`, `md` radius, `xs` text). Animation gates on `_open` / `_closed`, which already cover Base UI's `[data-open]` / `[data-closed]` attributes.
- `Content` exposes all twelve Positioner props (anchor, collision, positioning) rather than shadcn's minimal four — none collide with Popup's HTML surface, so there's no reason to hide them.
- Default `sideOffset` is `8` so the arrow tip clears the trigger instead of touching it.

Callers updated for Base UI's API: `asChild` → `render`, `delayDuration` on Root → `delay` on Trigger (Base UI puts delay on Provider/Trigger, not Root), `disableHoverableContent` → `disableHoverablePopup`. `Portal` and `Arrow` are no longer exported individually — `Content` owns them.

Also: `stylegen` now clears `src/app/styled-system` before regenerating so stale files from renamed recipes don't linger.