### PR TITLE
Migrate image processing to Bun.Image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@trpc/client": "~11.17.0",
         "@trpc/react-query": "~11.17.0",
         "@trpc/server": "~11.17.0",
-        "@types/bun": "~1.3.13",
+        "@types/bun": "~1.3.14",
         "airtable": "~0.12.2",
         "class-variance-authority": "~0.7.1",
         "clsx": "~2.1.1",
@@ -728,7 +728,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -832,7 +832,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-n-require": ["bundle-n-require@1.1.2", "", { "dependencies": { "esbuild": "^0.25.1", "node-eval": "^2.0.0" } }, "sha512-bEk2jakVK1ytnZ9R2AAiZEeK/GxPUM8jvcRxHZXifZDMcjkI4EG/GlsJ2YGSVYT9y/p/gA9/0yDY8rCGsSU6Tg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@trpc/client": "~11.17.0",
     "@trpc/react-query": "~11.17.0",
     "@trpc/server": "~11.17.0",
-    "@types/bun": "~1.3.13",
+    "@types/bun": "~1.3.14",
     "airtable": "~0.12.2",
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",

--- a/src/server/lib/image-metadata.ts
+++ b/src/server/lib/image-metadata.ts
@@ -11,9 +11,7 @@ const SVG_HEIGHT_PATTERN = /height\s*=\s*["']?([\d.]+)(?:px)?["']?/i;
 const SVG_VIEWBOX_PATTERN = /viewBox\s*=\s*["']?([\d.\s]+)["']?/i;
 
 // Bun.Image only handles raster formats; SVG needs a separate path.
-function readSvgDimensions(
-  buffer: ArrayBuffer
-): { width: number; height: number } | null {
+function readSvgDimensions(buffer: ArrayBuffer): { width: number; height: number } | null {
   const head = Math.min(buffer.byteLength, 2048);
   const text = new TextDecoder().decode(buffer.slice(0, head));
   const tagMatch = SVG_TAG_PATTERN.exec(text);

--- a/src/server/lib/image-metadata.ts
+++ b/src/server/lib/image-metadata.ts
@@ -1,184 +1,53 @@
-type ImageFormat = 'png' | 'jpeg' | 'gif' | 'bmp' | 'webp' | 'svg';
-
 export interface ImageMetadata {
-  format: ImageFormat;
+  format: string;
   width: number;
   height: number;
   size: number;
 }
 
-export function getImageMetadata(buffer: ArrayBuffer): ImageMetadata {
-  const view = new DataView(buffer);
+const SVG_TAG_PATTERN = /<svg[^>]*>/i;
+const SVG_WIDTH_PATTERN = /width\s*=\s*["']?([\d.]+)(?:px)?["']?/i;
+const SVG_HEIGHT_PATTERN = /height\s*=\s*["']?([\d.]+)(?:px)?["']?/i;
+const SVG_VIEWBOX_PATTERN = /viewBox\s*=\s*["']?([\d.\s]+)["']?/i;
+
+// Bun.Image only handles raster formats; SVG needs a separate path.
+function readSvgDimensions(
+  buffer: ArrayBuffer
+): { width: number; height: number } | null {
+  const head = Math.min(buffer.byteLength, 2048);
+  const text = new TextDecoder().decode(buffer.slice(0, head));
+  const tagMatch = SVG_TAG_PATTERN.exec(text);
+  if (!tagMatch) return null;
+
+  const tag = tagMatch[0];
+  const widthMatch = SVG_WIDTH_PATTERN.exec(tag);
+  const heightMatch = SVG_HEIGHT_PATTERN.exec(tag);
+  if (widthMatch && heightMatch) {
+    return {
+      width: parseFloat(widthMatch[1]!),
+      height: parseFloat(heightMatch[1]!),
+    };
+  }
+
+  const viewBoxMatch = SVG_VIEWBOX_PATTERN.exec(tag);
+  if (viewBoxMatch) {
+    const [, , width, height] = viewBoxMatch[1]!.trim().split(/\s+/).map(Number);
+    if (width !== undefined && height !== undefined) {
+      return { width, height };
+    }
+  }
+
+  throw new Error('SVG missing explicit width/height or viewBox');
+}
+
+export async function getImageMetadata(buffer: ArrayBuffer): Promise<ImageMetadata> {
   const size = buffer.byteLength;
 
-  // helper to read 24‑bit little‑endian
-  const getUint24LE = (off: number) =>
-    view.getUint8(off) | (view.getUint8(off + 1) << 8) | (view.getUint8(off + 2) << 16);
-
-  // PNG: signature 0x89 'PNG'
-  if (view.getUint32(0) === 0x89504e47) {
-    const width = view.getUint32(16, false);
-    const height = view.getUint32(20, false);
-    return { format: 'png', width, height, size };
+  const svgDimensions = readSvgDimensions(buffer);
+  if (svgDimensions) {
+    return { format: 'svg', ...svgDimensions, size };
   }
 
-  // JPEG: SOI marker 0xFFD8
-  if (view.getUint16(0) === 0xffd8) {
-    let offset = 2;
-    while (offset < view.byteLength) {
-      if (view.getUint8(offset) !== 0xff) break;
-      const marker = view.getUint8(offset + 1);
-      const length = view.getUint16(offset + 2, false);
-      // SOF0–SOF3 carry dimensions
-      if (marker >= 0xc0 && marker <= 0xc3) {
-        const height = view.getUint16(offset + 5, false);
-        const width = view.getUint16(offset + 7, false);
-        return { format: 'jpeg', width, height, size };
-      }
-      offset += 2 + length;
-    }
-    throw new Error('Invalid or unsupported JPEG');
-  }
-
-  // GIF: ASCII "GIF"
-  if (view.getUint8(0) === 0x47 && view.getUint8(1) === 0x49 && view.getUint8(2) === 0x46) {
-    const width = view.getUint16(6, true);
-    const height = view.getUint16(8, true);
-    return { format: 'gif', width, height, size };
-  }
-
-  // BMP: ASCII "BM"
-  if (view.getUint8(0) === 0x42 && view.getUint8(1) === 0x4d) {
-    const width = view.getUint32(18, true);
-    const height = view.getUint32(22, true);
-    return { format: 'bmp', width, height, size };
-  }
-
-  // WebP: RIFF…WEBP
-  const riff = String.fromCharCode(
-    view.getUint8(0),
-    view.getUint8(1),
-    view.getUint8(2),
-    view.getUint8(3)
-  );
-  const webp = String.fromCharCode(
-    view.getUint8(8),
-    view.getUint8(9),
-    view.getUint8(10),
-    view.getUint8(11)
-  );
-  if (riff === 'RIFF' && webp === 'WEBP') {
-    let offset = 12; // Start scanning chunks after 'WEBP' identifier
-
-    // First pass: Look for VP8X chunk, as it defines the canonical canvas dimensions
-    while (offset + 8 <= view.byteLength) {
-      // Ensure chunk header can be read
-      const chunkId = String.fromCharCode(
-        view.getUint8(offset),
-        view.getUint8(offset + 1),
-        view.getUint8(offset + 2),
-        view.getUint8(offset + 3)
-      );
-      const chunkSize = view.getUint32(offset + 4, true);
-      const payloadOffset = offset + 8;
-
-      if (payloadOffset + chunkSize > view.byteLength) {
-        throw new Error('WebP chunk size exceeds file bounds');
-      }
-
-      if (chunkId === 'VP8X') {
-        if (chunkSize < 10) throw new Error('Invalid VP8X chunk size');
-        const width = getUint24LE(payloadOffset + 4) + 1;
-        const height = getUint24LE(payloadOffset + 7) + 1;
-        return { format: 'webp', width, height, size }; // VP8X provides definitive dimensions
-      }
-
-      const padding = chunkSize % 2 === 1 ? 1 : 0;
-      offset += 8 + chunkSize + padding; // Move to the next chunk
-    }
-
-    // Second pass: If VP8X wasn't found, look for VP8 (lossy) or VP8L (lossless)
-    offset = 12; // Reset offset
-    while (offset + 8 <= view.byteLength) {
-      // Ensure chunk header can be read
-      const chunkId = String.fromCharCode(
-        view.getUint8(offset),
-        view.getUint8(offset + 1),
-        view.getUint8(offset + 2),
-        view.getUint8(offset + 3)
-      );
-      const chunkSize = view.getUint32(offset + 4, true);
-      const payloadOffset = offset + 8;
-
-      if (payloadOffset + chunkSize > view.byteLength) {
-        throw new Error('WebP chunk size exceeds file bounds');
-      }
-
-      if (chunkId === 'VP8 ') {
-        // Simple lossy format
-        if (chunkSize < 10) throw new Error('Invalid VP8 chunk size');
-        // Dimensions are at offset 6 & 8 within the payload, lower 14 bits
-        const width = view.getUint16(payloadOffset + 6, true) & 0x3fff;
-        const height = view.getUint16(payloadOffset + 8, true) & 0x3fff;
-        return { format: 'webp', width, height, size };
-      } else if (chunkId === 'VP8L') {
-        // Lossless format
-        if (chunkSize < 5) throw new Error('Invalid VP8L chunk size');
-        if (view.getUint8(payloadOffset) !== 0x2f) {
-          // Check signature byte
-          throw new Error('Invalid VP8L signature byte');
-        }
-        const bits = view.getUint32(payloadOffset + 1, true); // Read 4 bytes after signature
-        const width = (bits & 0x3fff) + 1; // Low 14 bits
-        const height = ((bits >> 14) & 0x3fff) + 1; // Next 14 bits
-        return { format: 'webp', width, height, size };
-      }
-
-      const padding = chunkSize % 2 === 1 ? 1 : 0;
-      offset += 8 + chunkSize + padding; // Move to the next chunk
-    }
-
-    // If no dimension-containing chunk (VP8X, VP8 , VP8L) was found
-    throw new Error('WebP dimension chunk not found or file invalid');
-  }
-
-  // SVG: look for an <svg> tag in the first 2KB
-  {
-    const head = buffer.byteLength < 2048 ? buffer.byteLength : 2048;
-    const text = new TextDecoder().decode(buffer.slice(0, head));
-    const svgTag = /<svg[^>]*>/i.exec(text);
-    if (svgTag) {
-      const tag = svgTag[0];
-      // try width/height attributes
-      const wMatch = /width\s*=\s*["']?([\d.]+)(?:px)?["']?/i.exec(tag);
-      const hMatch = /height\s*=\s*["']?([\d.]+)(?:px)?["']?/i.exec(tag);
-      if (wMatch && hMatch) {
-        const wStr = wMatch[1]!;
-        const hStr = hMatch[1]!;
-        return {
-          format: 'svg',
-          width: parseFloat(wStr),
-          height: parseFloat(hStr),
-          size,
-        };
-      }
-      // fallback to viewBox
-      const vbMatch = /viewBox\s*=\s*["']?([\d.\s]+)["']?/i.exec(tag);
-      if (vbMatch) {
-        const parts = vbMatch[1]!.trim().split(/\s+/).map(Number);
-        const [, , wNum, hNum] = parts;
-        if (wNum !== undefined && hNum !== undefined) {
-          return {
-            format: 'svg',
-            width: wNum,
-            height: hNum,
-            size,
-          };
-        }
-      }
-      throw new Error('SVG missing explicit width/height or viewBox');
-    }
-  }
-
-  throw new Error('Unsupported image format');
+  const { width, height, format } = await new Bun.Image(buffer).metadata();
+  return { format, width, height, size };
 }

--- a/src/server/lib/media.ts
+++ b/src/server/lib/media.ts
@@ -156,7 +156,7 @@ export async function getSmartMetadata(url: string): Promise<MediaMetadata> {
     }
 
     const buffer = await response.arrayBuffer();
-    const metadata = getImageMetadata(buffer);
+    const metadata = await getImageMetadata(buffer);
 
     return {
       mediaType,

--- a/src/server/services/generate-alt-text.ts
+++ b/src/server/services/generate-alt-text.ts
@@ -18,7 +18,7 @@ const ALT_TEXT_WORKER_TIMEOUT_MS = 180_000;
 const COMMAND_TIMEOUT_MS = 45_000;
 const IMAGE_DIRECT_INPUT_MAX_BYTES = 8 * 1024 * 1024;
 const IMAGE_DOWNSAMPLE_MAX_DIMENSION = 2048;
-const IMAGE_DOWNSAMPLE_JPEG_QUALITY = 6;
+const IMAGE_DOWNSAMPLE_JPEG_QUALITY = 85;
 const VIDEO_FRAME_MAX_DIMENSION = 1600;
 const VIDEO_FRAME_JPEG_QUALITY = 6;
 const VIDEO_FRAME_FRACTIONS = [0, 0.5, 0.9];
@@ -312,15 +312,6 @@ async function runCommand(
   }
 }
 
-function sanitizeExtension(value: string): string {
-  const normalized = value.trim().toLowerCase();
-  if (/^[a-z0-9]+$/.test(normalized)) {
-    return normalized;
-  }
-
-  return 'bin';
-}
-
 async function rasterizeSvgToPng(
   svgBytes: Uint8Array,
   signal?: AbortSignal
@@ -384,54 +375,36 @@ async function fetchBinary(url: string, signal?: AbortSignal): Promise<BinaryFet
 
 async function downsampleImageToJpeg(
   imageBytes: Uint8Array,
-  inputFormat: string,
   signal?: AbortSignal
 ): Promise<DownsampleImageResult> {
-  const tempDir = await mkdtemp(join(tmpdir(), 'rcr-alt-text-image-'));
-  const inputPath = join(tempDir, `input.${sanitizeExtension(inputFormat)}`);
-  const outputPath = join(tempDir, 'output.jpg');
+  if (signal?.aborted) {
+    return { ok: false, error: timeoutErrorMessage() };
+  }
 
   try {
-    await writeFile(inputPath, imageBytes);
+    const bytes = await new Bun.Image(imageBytes)
+      .resize(IMAGE_DOWNSAMPLE_MAX_DIMENSION, IMAGE_DOWNSAMPLE_MAX_DIMENSION, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .jpeg({ quality: IMAGE_DOWNSAMPLE_JPEG_QUALITY })
+      .bytes();
 
-    const downsampleResult = await runCommand(
-      [
-        'ffmpeg',
-        '-hide_banner',
-        '-loglevel',
-        'error',
-        '-y',
-        '-i',
-        inputPath,
-        '-frames:v',
-        '1',
-        '-vf',
-        `scale=${IMAGE_DOWNSAMPLE_MAX_DIMENSION}:${IMAGE_DOWNSAMPLE_MAX_DIMENSION}:force_original_aspect_ratio=decrease`,
-        '-q:v',
-        `${IMAGE_DOWNSAMPLE_JPEG_QUALITY}`,
-        outputPath,
-      ],
-      { signal, timeoutMs: COMMAND_TIMEOUT_MS }
-    );
-
-    if (!downsampleResult.ok) {
-      return { ok: false, error: downsampleResult.error };
+    if (signal?.aborted) {
+      return { ok: false, error: timeoutErrorMessage() };
     }
 
-    const outputBytes = await readFile(outputPath);
-    if (outputBytes.byteLength === 0) {
+    if (bytes.byteLength === 0) {
       return { ok: false, error: 'Downsampled image is empty' };
     }
 
-    return { ok: true, bytes: new Uint8Array(outputBytes) };
+    return { ok: true, bytes };
   } catch (error) {
     if (signal?.aborted) {
       return { ok: false, error: timeoutErrorMessage() };
     }
 
     return { ok: false, error: toErrorMessage(error) };
-  } finally {
-    await rm(tempDir, { force: true, recursive: true });
   }
 }
 
@@ -483,7 +456,7 @@ async function prepareImageForVision(
       };
     }
 
-    const downsampled = await downsampleImageToJpeg(rasterized.bytes, 'png', signal);
+    const downsampled = await downsampleImageToJpeg(rasterized.bytes, signal);
     if (!downsampled.ok) {
       return { ok: false, error: `Image downsample failed: ${downsampled.error}` };
     }
@@ -513,7 +486,7 @@ async function prepareImageForVision(
     };
   }
 
-  const downsampled = await downsampleImageToJpeg(fetched.bytes, mediaItem.format, signal);
+  const downsampled = await downsampleImageToJpeg(fetched.bytes, signal);
   if (!downsampled.ok) {
     const formatIsDirect = OPENAI_DIRECT_IMAGE_FORMATS.includes(mediaItem.format.toLowerCase());
     const exceedsByteLimit = fetched.bytes.byteLength > IMAGE_DIRECT_INPUT_MAX_BYTES;

--- a/src/server/services/generate-alt-text.ts
+++ b/src/server/services/generate-alt-text.ts
@@ -20,7 +20,8 @@ const IMAGE_DIRECT_INPUT_MAX_BYTES = 8 * 1024 * 1024;
 const IMAGE_DOWNSAMPLE_MAX_DIMENSION = 2048;
 const IMAGE_DOWNSAMPLE_JPEG_QUALITY = 85;
 const VIDEO_FRAME_MAX_DIMENSION = 1600;
-const VIDEO_FRAME_JPEG_QUALITY = 6;
+// ffmpeg -q:v qscale for mjpeg (2 best, 31 worst); roughly equivalent to JPEG quality ~85.
+const VIDEO_FRAME_FFMPEG_QSCALE = 6;
 const VIDEO_FRAME_FRACTIONS = [0, 0.5, 0.9];
 const ALT_TEXT_MEDIA_TYPES: Array<'image' | 'video'> = ['image', 'video'];
 const OPENAI_DIRECT_IMAGE_FORMATS = ['jpeg', 'jpg', 'png', 'gif', 'webp'];
@@ -615,7 +616,7 @@ async function extractVideoFramesForVision(
           '-vf',
           `scale=${VIDEO_FRAME_MAX_DIMENSION}:${VIDEO_FRAME_MAX_DIMENSION}:force_original_aspect_ratio=decrease`,
           '-q:v',
-          `${VIDEO_FRAME_JPEG_QUALITY}`,
+          `${VIDEO_FRAME_FFMPEG_QSCALE}`,
           outputPath,
         ],
         { signal, timeoutMs: COMMAND_TIMEOUT_MS }


### PR DESCRIPTION
Bun 1.3 ships `Bun.Image`, a chainable native pipeline for decoding, resizing, and re-encoding images. Two surfaces in this codebase collapse into single-call chains:

- `getImageMetadata` drops ~175 lines of hand-rolled chunk-walking (SOI/IDAT/RIFF/VP8X) in favor of `await new Bun.Image(buffer).metadata()`. The SVG branch stays — `Bun.Image` only handles raster formats — so the function sniffs SVG first and hands every other format to Bun.
- `downsampleImageToJpeg` (the OpenAI vision pre-processing step) replaces an `ffmpeg` subprocess plus a temp-directory dance with a `Bun.Image(...).resize(...).jpeg(...)` chain. Decode and encode run off the JS thread; the `inputFormat` parameter and the `sanitizeExtension` helper drop out as dead weight.

The two ffmpeg paths without a `Bun.Image` equivalent — video frame extraction and SVG rasterization via `sips` — are unchanged.

Parked until `Bun.Image` lands in stable Bun. The runtime exists in canary 1.3.14 only; stable 1.3.13 doesn't expose it, and `bun-types` hasn't shipped declarations either. Picking back up means bumping `bun-types` once typings ship, then running `bun check`.

Supersedes #118 (renamed branch).