### PR TITLE
Add keyboard shortcuts to similar-records type filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/app/lib/keyboard-shortcuts/parse.ts
+++ b/src/app/lib/keyboard-shortcuts/parse.ts
@@ -113,9 +113,15 @@ export function matchesShortcut(event: KeyboardEvent, parsed: ParsedShortcut): b
   if (event.altKey && !hasAlt) return false;
   if (event.shiftKey && !hasShift) return false;
 
-  // Check the main key
+  // Check the main key. For digits, also accept a match by physical key position
+  // (event.code) so the shortcut fires even when a modifier remaps the produced
+  // character — e.g. on macOS Option+1 reports event.key '¡' but event.code stays 'Digit1'.
   const normalizedEventKey = normalizeKey(event.key);
-  return normalizedEventKey === parsed.key;
+  if (normalizedEventKey === parsed.key) return true;
+  if (/^\d$/.test(parsed.key)) {
+    return event.code === `Digit${parsed.key}` || event.code === `Numpad${parsed.key}`;
+  }
+  return false;
 }
 
 /**

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -1,4 +1,4 @@
-import { RecordTypeSchema, type RecordType } from '@hozo/schema/records.shared';
+import type { RecordType } from '@hozo/schema/records.shared';
 import { useForm } from '@tanstack/react-form';
 import { useRouterState } from '@tanstack/react-router';
 import { BadgeCheckIcon, BadgeIcon, EyeIcon, EyeOffIcon } from 'lucide-react';
@@ -27,7 +27,7 @@ import type { RecordGet } from '@/shared/types/domain';
 import { css } from '@/styled-system/css';
 import { styled } from '@/styled-system/jsx';
 import { Metabar } from './record-metabar';
-import { recordTypeIcons } from './type-icons';
+import { recordTypeIcons, recordTypeOrder } from './type-icons';
 
 interface RecordFormProps extends React.HTMLAttributes<HTMLFormElement> {
   recordId: number;
@@ -375,7 +375,7 @@ export function RecordForm({
                   css={{ flexGrow: '1' }}
                   disabled={isFormLoading}
                 >
-                  {RecordTypeSchema.options.map((type) => {
+                  {recordTypeOrder.map((type) => {
                     const { icon: Icon, description } = recordTypeIcons[type];
                     return (
                       <Tooltip.Trigger

--- a/src/app/routes/records/-components/relations.tsx
+++ b/src/app/routes/records/-components/relations.tsx
@@ -332,12 +332,33 @@ export const RelationsList = ({ id }: RelationsListProps) => {
 /** Type filter for the similar records section. `all` clears the filter. */
 type SimilarTypeFilter = RecordType | 'all';
 
+// Order follows `recordTypeOrder` (with `all` first); Alt+<n> selects the nth filter.
 const SIMILAR_TYPE_FILTERS: { value: SimilarTypeFilter; label: string; icon: ElementType }[] = [
   { value: 'all', label: 'All types', icon: ShapesIcon },
   { value: 'artifact', label: 'Artifacts', icon: recordTypeIcons.artifact.icon },
-  { value: 'entity', label: 'Entities', icon: recordTypeIcons.entity.icon },
   { value: 'concept', label: 'Concepts', icon: recordTypeIcons.concept.icon },
+  { value: 'entity', label: 'Entities', icon: recordTypeIcons.entity.icon },
 ];
+
+/** Registers Alt+<n> to select a similar-records type filter. Renders nothing. */
+const SimilarTypeShortcut = ({
+  shortcut,
+  value,
+  label,
+  onSelect,
+}: {
+  shortcut: string;
+  value: SimilarTypeFilter;
+  label: string;
+  onSelect: (value: SimilarTypeFilter) => void;
+}) => {
+  useKeyboardShortcut(shortcut, () => onSelect(value), {
+    description: `Filter similar records: ${label}`,
+    category: 'Records',
+    allowInInput: true,
+  });
+  return null;
+};
 
 export const SimilarRecords = ({ id }: { id: DbId }) => {
   const navigate = useNavigate();
@@ -367,6 +388,15 @@ export const SimilarRecords = ({ id }: { id: DbId }) => {
 
   return (
     <styled.section css={{ textStyle: 'xs' }}>
+      {SIMILAR_TYPE_FILTERS.map((filter, index) => (
+        <SimilarTypeShortcut
+          key={filter.value}
+          shortcut={`alt+${index + 1}`}
+          value={filter.value}
+          label={filter.label}
+          onSelect={setTypeFilter}
+        />
+      ))}
       <styled.header
         css={{
           display: 'flex',

--- a/src/app/routes/records/-components/type-icons.tsx
+++ b/src/app/routes/records/-components/type-icons.tsx
@@ -2,6 +2,7 @@ import type { RecordType } from '@hozo/schema/records';
 import { FileTextIcon, LightbulbIcon, UserIcon } from 'lucide-react';
 import { memo } from 'react';
 import { Tooltip } from '@/components/tooltip';
+import { exhaustive } from '@/shared/lib/type-utils';
 
 // Map record types to their corresponding icons and descriptions
 export const recordTypeIcons: Record<RecordType, { icon: React.ElementType; description: string }> =
@@ -10,6 +11,13 @@ export const recordTypeIcons: Record<RecordType, { icon: React.ElementType; desc
     concept: { icon: LightbulbIcon, description: 'A category, idea, or abstraction' },
     artifact: { icon: FileTextIcon, description: 'Physical or digital objects, content, or media' },
   };
+
+/**
+ * Record types in display order, shared by the record form's type toggle and the
+ * similar-records type filter so both present the same sequence. Distinct from the
+ * schema's `recordTypes` order, which is fixed by the `record_type` Postgres enum.
+ */
+export const recordTypeOrder = exhaustive<RecordType>()(['artifact', 'concept', 'entity']);
 
 interface RecordTypeIconProps extends React.HTMLAttributes<SVGElement> {
   type: RecordType;


### PR DESCRIPTION
The similar-records type filter had no keyboard access, and its toggles were ordered differently from the record form's type selector. Alt+1 through Alt+4 now select the All, Artifacts, Concepts, and Entities filters in order, and both that filter and the form's type toggle draw from a shared `recordTypeOrder` constant so they present record types in the same sequence — kept separate from the schema's `recordTypes`, whose order is pinned by the `record_type` Postgres enum. Digit shortcuts also match by physical key position (`event.code`) so they fire on macOS, where Option+digit remaps the typed character (Option+1 produces `¡`).