### PR TITLE
Prepare hozo for consumption by barnsworthburning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "drizzle-kit": "1.0.0-rc.4",
         "drizzle-orm": "1.0.0-rc.4",
         "tsup": "~8.5.1",
+        "typescript": "~6.0.3",
         "zod": "~4.4.3",
       },
       "peerDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/hozo": {
       "name": "@aias/hozo",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "drizzle-kit": "1.0.0-rc.4",
         "drizzle-orm": "1.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/packages/hozo/package.json
+++ b/packages/hozo/package.json
@@ -21,16 +21,16 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunx --bun tsup src/index.ts --dts --format esm --sourcemap --clean",
-    "dev:watch": "bun run build --watch",
+    "dev:watch": "tsup src/index.ts --dts --format esm --sourcemap --watch",
     "lint": "oxlint --fix --type-aware . && tsgo --noEmit",
-    "prepublishOnly": "bun run build",
+    "prepare": "tsup src/index.ts --dts --format esm --sourcemap --clean",
     "test": "bun test"
   },
   "devDependencies": {
     "drizzle-kit": "1.0.0-rc.4",
     "drizzle-orm": "1.0.0-rc.4",
     "tsup": "~8.5.1",
+    "typescript": "~6.0.3",
     "zod": "~4.4.3"
   },
   "peerDependencies": {

--- a/packages/hozo/package.json
+++ b/packages/hozo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/hozo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared schema, relations, and validation for Red Cliff Record",
   "license": "MIT",
   "files": [
@@ -23,7 +23,7 @@
   "scripts": {
     "dev:watch": "tsup src/index.ts --dts --format esm --sourcemap --watch",
     "lint": "oxlint --fix --type-aware . && tsgo --noEmit",
-    "prepare": "tsup src/index.ts --dts --format esm --sourcemap --clean",
+    "prepack": "tsup src/index.ts --dts --format esm --sourcemap --clean",
     "test": "bun test"
   },
   "devDependencies": {


### PR DESCRIPTION
barnsworthburning is migrating off Airtable onto the rcr database, consuming @hozo as its schema package (https://github.com/Aias/barnsworthburning/pull/65). hozo needs to build for external consumers.

Replaces the build/prepublishOnly scripts with a single prepack script, which runs with devDependencies installed during both npm/bun publish and package-manager git/file installs. Adds typescript to hozo's devDependencies so tsup's dts generation works outside the workspace (it previously relied on root hoisting), and bumps hozo to 0.4.0 ahead of republishing to npm.