### PR TITLE
Rebuild the color system around palette, chromatic, and mode utilities

### DIFF
--- a/.agents/skills/rcr-frontend/SKILL.md
+++ b/.agents/skills/rcr-frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rcr-frontend
-description: Component and styling conventions for Red Cliff Record. Use when writing, reviewing, or refactoring any frontend code under `src/app/` — components, routes, styles, forms, icons, animations. Triggers on `.tsx`/`.css` edits in this project, design tokens, Panda CSS recipes, Base UI primitives, TanStack Form/Router, Lucide icons, color palettes (`data-palette`, `colorPalette`), or questions like "how do I style X in RCR". Also invoke proactively before UI work to ensure Panda-first styling and Base UI primitives, and to clean up legacy Tailwind/Radix in any file you touch.
+description: Component and styling conventions for Red Cliff Record. Use when writing, reviewing, or refactoring any frontend code under `src/app/` — components, routes, styles, forms, icons, animations. Triggers on `.tsx`/`.css` edits in this project, design tokens, Panda CSS recipes, Base UI primitives, TanStack Form/Router, Lucide icons, color palettes (`palette`, `chromatic`, `mode`), or questions like "how do I style X in RCR". Also invoke proactively before UI work to ensure Panda-first styling and Base UI primitives, and to clean up legacy Tailwind/Radix in any file you touch.
 ---
 
 # RCR Frontend
@@ -80,14 +80,14 @@ export function Toolbar({ css: cssProp }: { css?: SystemStyleObject }) {
 
 Everything lives under `src/app/styles/`:
 
-| File                                                       | Contents                                                       |
-| ---------------------------------------------------------- | -------------------------------------------------------------- |
-| `colors.ts`                                                | Semantic tokens + semantic palettes + Radix color scales       |
-| `typography.ts`                                            | `textStyle` values, font families, sizes, weights              |
-| `dimensions.ts`                                            | `spacing` and `sizes` (multiples of `0.25rem`, plus fractions) |
-| `borders.ts` / `radii.ts` / `shadows.ts` / `animations.ts` | Their namesakes                                                |
-| `conditions.ts`                                            | Custom Panda conditions                                        |
-| `plugins.ts`                                               | Custom utilities (`animateIn`, `fadeIn`, `translateCenter`, …) |
+| File                                                       | Contents                                                          |
+| ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| `colors.ts`                                                | Color engine: Radix hue ramps, palettes, semantic formulas        |
+| `typography.ts`                                            | `textStyle` values, font families, sizes, weights                 |
+| `dimensions.ts`                                            | `spacing` and `sizes` (multiples of `0.25rem`, plus fractions)    |
+| `borders.ts` / `radii.ts` / `shadows.ts` / `animations.ts` | Their namesakes                                                   |
+| `conditions.ts`                                            | Custom Panda conditions                                           |
+| `plugins.ts`                                               | Custom utilities (`palette`, `chromatic`, `mode`, `animateIn`, …) |
 
 ### Semantic color tokens (use these, not Radix scales directly)
 
@@ -95,28 +95,27 @@ Everything lives under `src/app/styles/`:
 
 Use them as token names in Panda (`color: 'primary'`, `backgroundColor: 'float'`). The `c-*` names (`bg-c-paper`, `text-c-primary`) are the Tailwind aliases — only relevant while removing Tailwind from legacy components. In Panda code, `c-paper` doesn't exist; the equivalent is `float` or `surface` depending on intent (check existing usage).
 
-### Palette-aware components via `colorPalette` and `layerStyle`
+### Theme boundaries via `palette`, `chromatic`, and `mode`
 
-Two style properties steer semantic tokens within a subtree. Use them as Panda CSS properties — not HTML attributes.
+Three inherited axes steer every semantic color token. Set any of them anywhere in the tree and the whole subtree re-resolves against the new context until a descendant sets that axis again.
 
-| Property       | Values                                                      | Effect                                                                                                                                      |
-| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `colorPalette` | `artifact`, `entity`, `concept`, `error`, `success`, `info` | Remaps every semantic color under this element to the chosen palette (tokens like `accent`, `main`, `splash` resolve through that palette). |
-| `layerStyle`   | `chromatic`, `neutral`                                      | Picks the chromatic or neutral variant of the active palette. Activates the `_chromatic` / `_neutral` conditions inside recipes.            |
+| Utility     | Values                                                      | Effect                                                                                                                       |
+| ----------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `palette`   | `artifact`, `entity`, `concept`, `error`, `success`, `info` | Selects the hue ramps (chromatic + associated neutral) that semantic tokens like `accent`, `main`, `splash` resolve through. |
+| `chromatic` | `true`, `false`                                             | Switches every semantic token between its chromatic and neutral variant.                                                     |
+| `mode`      | `dark`, `light`, `inverted`, `normal`                       | Sets `color-scheme`; all colors are `light-dark()` pairs, so the subtree flips instantly.                                    |
 
 ```tsx
-<styled.span css={{ colorPalette: 'error', backgroundColor: 'splash', color: 'accent' }}>
+<styled.span css={{ palette: 'error', chromatic: true, backgroundColor: 'splash', color: 'accent' }}>
   Error
 </styled.span>
 
-<styled.section css={{ colorPalette: 'info', layerStyle: 'chromatic' }}>
-  {/* Uses the chromatic variant of the `info` palette inside */}
+<styled.section css={{ palette: 'info', chromatic: true }}>
+  {/* Everything inside uses the chromatic variant of the `info` palette */}
 </styled.section>
 ```
 
-Inside a recipe, gate a palette swap on a variant or condition — e.g. `_invalid: { colorPalette: 'error' }` on button/textarea input states.
-
-**Escape hatch — `data-palette` / `data-chromatic`.** These HTML attributes still work (they're wired up in `src/app/styles/theme.css` and `conditions.ts`) and are fine when the element is rendered outside Panda's reach: third-party components that only accept HTML attributes, markdown-generated DOM, server-rendered bootstrap wrappers, etc. For anything authored with `css({ ... })` or `styled.*`, prefer `colorPalette` and `layerStyle`.
+They work identically inside recipes — e.g. `_invalid: { palette: 'error', chromatic: true }` on input states. Each boundary also re-asserts `color: primary` at base-layer precedence, so plain inherited text adapts across the boundary while any explicit `color` still wins.
 
 ### Text styles
 
@@ -140,12 +139,10 @@ Numeric tokens are `0.25rem` multiples: `0, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 
 | ------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_dark`                                                 | `:where([data-color-scheme="dark"], .dark) &`   | Color-scheme-scoped overrides                                                                                                                                               |
 | `_light`                                                | `:where([data-color-scheme="light"], .light) &` | Color-scheme-scoped overrides                                                                                                                                               |
-| `_neutral`                                              | `&[data-neutral]` (+ scope variants)            | Triggered by `layerStyle: 'neutral'` (or `data-neutral` as escape hatch).                                                                                                   |
-| `_chromatic`                                            | `&[data-chromatic]` (+ scope variants)          | Triggered by `layerStyle: 'chromatic'` (or `data-chromatic` as escape hatch).                                                                                               |
 | `_childIcon`                                            | `& :where(svg, .icon, .lucide)`                 | Size/color icons inside a container. Prefer over `& svg`.                                                                                                                   |
 | `_sideBottom` / `_sideTop` / `_sideLeft` / `_sideRight` | `&[data-side=<side>]`                           | Radix/popper-positioned content (popover, dropdown, hover-card) — directional slide-in animation per placement. Use these instead of raw `'&[data-side=bottom]'` selectors. |
 
-Reach for a defined condition over a raw `[data-*]` selector — but **first check Panda's built-ins so you don't duplicate one**: `_vertical` / `_horizontal` (`[data-orientation]`), `_open` / `_closed` (`[data-state]`), `_hover`, `_focusVisible`, `_disabled`, `_invalid`, `_placeholder`, and the `_group*` / `_peer*` families all ship out of the box. Only when Panda has nothing (e.g. the project's `_side*`, `_chromatic` / `_neutral`) add it to `styles/conditions.ts` (and `bun run stylegen`) rather than inlining the attribute selector in a recipe.
+Reach for a defined condition over a raw `[data-*]` selector — but **first check Panda's built-ins so you don't duplicate one**: `_vertical` / `_horizontal` (`[data-orientation]`), `_open` / `_closed` (`[data-state]`), `_hover`, `_focusVisible`, `_disabled`, `_invalid`, `_placeholder`, and the `_group*` / `_peer*` families all ship out of the box. Only when Panda has nothing (e.g. the project's `_side*`, `_childIcon`) add it to `styles/conditions.ts` (and `bun run stylegen`) rather than inlining the attribute selector in a recipe.
 
 Useful utilities (full list in `src/app/styles/plugins.ts`):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -22,7 +22,7 @@ import { tooltipRecipe } from '@/app/components/tooltip/tooltip.recipe';
 import { easings, durations, keyframes } from '@/app/styles/animations';
 import { blurs } from '@/app/styles/blurs';
 import { borders } from '@/app/styles/borders';
-import { colors, semanticColors } from '@/app/styles/colors';
+import { colors } from '@/app/styles/colors';
 import { conditionsPreset } from '@/app/styles/conditions';
 import { spacing, sizes } from '@/app/styles/dimensions';
 import { globalStyles } from '@/app/styles/globals';
@@ -51,16 +51,6 @@ export default defineConfig({
 
   presets: [conditionsPreset],
   globalCss: globalStyles,
-  staticCss: {
-    css: [
-      {
-        properties: {
-          layerStyle: ['chromatic', 'neutral'],
-          palette: ['artifact', 'entity', 'concept', 'error', 'success', 'info'],
-        },
-      },
-    ],
-  },
   theme: {
     extend: {
       tokens: {
@@ -78,17 +68,9 @@ export default defineConfig({
         sizes: sizes,
         spacing: spacing,
       },
-      semanticTokens: {
-        colors: semanticColors,
-      },
     },
     keyframes: keyframes,
     textStyles: textStyles,
-    layerStyles: {
-      // Empty declarations, only for autocomplete and class name generation
-      chromatic: { value: {} },
-      neutral: { value: {} },
-    },
     breakpoints: {
       sm: '40rem',
       md: '48rem',

--- a/src/app/components/button/button.recipe.ts
+++ b/src/app/components/button/button.recipe.ts
@@ -28,7 +28,8 @@ export const buttonRecipe = defineRecipe({
       boxSize: '[1.15em]',
     },
     _invalid: {
-      colorPalette: 'error',
+      palette: 'error',
+      chromatic: true,
     },
     _focusVisible: {
       borderColor: 'focus',

--- a/src/app/components/dropdown-menu/dropdown-menu.recipe.ts
+++ b/src/app/components/dropdown-menu/dropdown-menu.recipe.ts
@@ -88,8 +88,8 @@ export const dropdownMenuRecipe = defineSlotRecipe({
       paddingInline: '2',
       '&[data-inset]': { paddingInlineStart: '8' },
       '&[data-variant=destructive]': {
-        colorPalette: 'error',
-        layerStyle: 'chromatic',
+        palette: 'error',
+        chromatic: true,
         color: 'accent',
         _highlighted: {
           backgroundColor: 'splash',

--- a/src/app/components/input/input.recipe.ts
+++ b/src/app/components/input/input.recipe.ts
@@ -39,8 +39,8 @@ export const inputRecipe = defineRecipe({
       outlineWidth: '2px',
     },
     _invalid: {
-      layerStyle: 'chromatic',
-      colorPalette: 'error',
+      palette: 'error',
+      chromatic: true,
     },
     _selection: {
       backgroundColor: 'main',

--- a/src/app/components/media-upload.tsx
+++ b/src/app/components/media-upload.tsx
@@ -197,8 +197,8 @@ export const MediaUpload = ({
             backgroundColor: 'main/10',
           },
           '&[data-error]': {
-            layerStyle: 'chromatic',
-            colorPalette: 'error',
+            palette: 'error',
+            chromatic: true,
             borderColor: 'accent',
           },
           _loading: {

--- a/src/app/components/textarea/textarea.recipe.ts
+++ b/src/app/components/textarea/textarea.recipe.ts
@@ -23,7 +23,8 @@ export const textareaRecipe = defineRecipe({
       color: 'muted',
     },
     _invalid: {
-      colorPalette: 'error',
+      palette: 'error',
+      chromatic: true,
     },
     _disabled: {
       opacity: '50%',

--- a/src/app/components/toggle/toggle.recipe.ts
+++ b/src/app/components/toggle/toggle.recipe.ts
@@ -25,12 +25,12 @@ export const toggleRecipe = defineRecipe({
     _pressed: {
       backgroundColor: 'splash',
       color: 'accent',
-      layerStyle: 'chromatic',
+      chromatic: true,
     },
     _disabled: {
       pointerEvents: 'none',
       opacity: '50%',
-      layerStyle: 'neutral',
+      chromatic: false,
     },
     _focusVisible: {
       borderColor: 'focus',

--- a/src/app/routes/-app-components/app-layout.tsx
+++ b/src/app/routes/-app-components/app-layout.tsx
@@ -52,7 +52,7 @@ export const AppLayout = ({ children, currentTheme, onThemeChange }: AppLayoutPr
           <LinkButton
             variant="solid"
             css={{
-              layerStyle: 'chromatic',
+              chromatic: true,
               _childIcon: {
                 opacity: '75%',
               },

--- a/src/app/routes/__root.tsx
+++ b/src/app/routes/__root.tsx
@@ -138,8 +138,7 @@ function RootDocument({
   return (
     <html
       className={css({
-        colorPalette: 'artifact',
-        layerStyle: 'neutral',
+        palette: 'artifact',
       })}
       data-color-scheme={appearance}
       data-theme-transitioning={isTransitioning || undefined}

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -40,7 +40,7 @@ function Home() {
         />
       )}
       {isError && (
-        <styled.p css={{ colorPalette: 'error', layerStyle: 'chromatic', color: 'accent' }}>
+        <styled.p css={{ palette: 'error', chromatic: true, color: 'accent' }}>
           Error loading records.
         </styled.p>
       )}

--- a/src/app/routes/records/$recordId.tsx
+++ b/src/app/routes/records/$recordId.tsx
@@ -334,7 +334,7 @@ function RouteComponent() {
       <styled.div
         css={{ display: 'flex', flex: '1', alignItems: 'center', justifyContent: 'center' }}
       >
-        <styled.div css={{ textAlign: 'center', colorPalette: 'error', layerStyle: 'chromatic' }}>
+        <styled.div css={{ textAlign: 'center', palette: 'error', chromatic: true }}>
           <styled.div css={{ marginBlockEnd: '2', color: 'accent' }}>Record not found</styled.div>
           <styled.div css={{ textStyle: 'sm', color: 'muted' }}>
             This record may have been deleted or moved.

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -336,8 +336,8 @@ export function RecordForm({
                 {field.state.meta.errors && (
                   <styled.p
                     css={{
-                      colorPalette: 'error',
-                      layerStyle: 'chromatic',
+                      palette: 'error',
+                      chromatic: true,
                       textStyle: 'sm',
                     }}
                   >
@@ -515,8 +515,8 @@ export function RecordForm({
                           {field.state.meta.errors && (
                             <styled.p
                               css={{
-                                colorPalette: 'error',
-                                layerStyle: 'chromatic',
+                                palette: 'error',
+                                chromatic: true,
                                 textStyle: 'sm',
                               }}
                             >

--- a/src/app/routes/records/-components/record-metabar.tsx
+++ b/src/app/routes/records/-components/record-metabar.tsx
@@ -144,7 +144,7 @@ export const Metabar = ({ recordId, onDelete, css: cssProp, ...props }: MetabarP
                 render={
                   <Button
                     variant="solid"
-                    css={{ colorPalette: 'error', layerStyle: 'chromatic' }}
+                    css={{ palette: 'error', chromatic: true }}
                     onClick={handleDelete}
                   >
                     Continue

--- a/src/app/styles/borders.ts
+++ b/src/app/styles/borders.ts
@@ -1,21 +1,26 @@
 import { defineTokens } from '@pandacss/dev';
 
+const semanticBorders = ['divider', 'border', 'edge', 'focus'] as const;
+
 export const borders = defineTokens.borders({
   none: { value: 'none' },
-  divider: {
-    DEFAULT: { value: '1px solid {colors.divider}' },
-    thin: { value: '0.5px solid {colors.divider}' },
-  },
-  border: {
-    DEFAULT: { value: '1px solid {colors.border}' },
-    thin: { value: '0.5px solid {colors.border}' },
-  },
-  edge: {
-    DEFAULT: { value: '1px solid {colors.edge}' },
-    thin: { value: '0.5px solid {colors.edge}' },
-  },
-  focus: {
-    DEFAULT: { value: '1px solid {colors.focus}' },
-    thin: { value: '0.5px solid {colors.focus}' },
-  },
+  ...Object.fromEntries(
+    semanticBorders.map((name) => [
+      name,
+      {
+        DEFAULT: { value: `1px solid {colors.${name}}` },
+        thin: { value: `0.5px solid {colors.${name}}` },
+      },
+    ])
+  ),
 });
+
+// Border tokens wrap semantic colors, and custom properties bake their var()
+// substitutions at the declaring element — so theme boundaries must re-declare
+// them alongside the color formulas to re-resolve against the new context.
+export const borderDeclarations: Record<`--${string}`, string> = Object.fromEntries(
+  semanticBorders.flatMap((name) => [
+    [`--borders-${name}`, `1px solid var(--colors-${name})`],
+    [`--borders-${name}-thin`, `0.5px solid var(--colors-${name})`],
+  ])
+);

--- a/src/app/styles/colors.ts
+++ b/src/app/styles/colors.ts
@@ -1,180 +1,57 @@
-import { defineSemanticTokens, defineTokens } from '@pandacss/dev';
+import { defineTokens } from '@pandacss/dev';
 import {
-  sand,
-  sandDark,
-  sage,
-  sageDark,
-  mauve,
-  mauveDark,
   amber,
   amberDark,
-  grass,
-  grassDark,
-  olive,
-  oliveDark,
-  teal,
-  tealDark,
-  iris,
-  irisDark,
-  tomato,
-  tomatoDark,
-  gold,
-  goldDark,
   bronze,
   bronzeDark,
-  gray,
-  grayDark,
-  brown,
-  brownDark,
+  gold,
+  goldDark,
+  grass,
+  grassDark,
+  iris,
+  irisDark,
+  mauve,
+  mauveDark,
+  olive,
+  oliveDark,
+  sand,
+  sandDark,
   slate,
   slateDark,
-  // blackA,
-  // whiteA,
+  tomato,
+  tomatoDark,
 } from '@radix-ui/colors';
+
+// ---------------------------------------------------------------------------
+// Color engine
+//
+// Three inherited axes, each settable anywhere in the tree:
+//   palette — `palette: 'artifact'` aliases a chromatic hue ramp to --clr-* and
+//             its associated neutral ramp to --neu-*
+//   chroma  — `chromatic: true | false` sets --chroma to 100% | 0%
+//   mode    — `mode: 'dark' | ...` sets color-scheme; light-dark() resolves at
+//             the consuming element, so mode needs no variable machinery
+//
+// Every semantic color token is a single formula over --clr-*, --neu-*, and
+// --chroma: color-mix(in oklch, <neutral variant>, <chromatic variant> var(--chroma)).
+// The --chroma dial (rather than baked-in variants) is what lets a palette
+// boundary stay chroma-agnostic and compose with chromaticity in any nesting
+// order.
+//
+// Custom properties substitute their var() references at the element where
+// they are declared, and descendants inherit the resolved stream. The palette
+// and chromatic utilities (plugins.ts) therefore re-declare every formula at
+// each boundary element so the subtree re-resolves against its new context.
+// ---------------------------------------------------------------------------
 
 const WHITE = 'oklch(1 0 0)';
 const BLACK = 'oklch(0 0 0)';
 
-type NeutralPaletteName = 'mauve' | 'slate' | 'sage' | 'olive' | 'sand' | 'gray';
-type ChromaticPaletteName =
-  | 'tomato'
-  | 'red'
-  | 'ruby'
-  | 'crimson'
-  | 'pink'
-  | 'plum'
-  | 'purple'
-  | 'violet'
-  | 'iris'
-  | 'indigo'
-  | 'blue'
-  | 'sky'
-  | 'cyan'
-  | 'mint'
-  | 'teal'
-  | 'jade'
-  | 'green'
-  | 'grass'
-  | 'lime'
-  | 'yellow'
-  | 'amber'
-  | 'orange'
-  | 'brown'
-  | 'gold'
-  | 'bronze';
+const lightDark = (light: string, dark: string) => `light-dark(${light}, ${dark})`;
 
-const neutralAssociations: Record<ChromaticPaletteName, NeutralPaletteName> = {
-  tomato: 'mauve',
-  red: 'mauve',
-  ruby: 'mauve',
-  crimson: 'mauve',
-  pink: 'mauve',
-  plum: 'mauve',
-  purple: 'mauve',
-  violet: 'mauve',
-  iris: 'slate',
-  indigo: 'slate',
-  blue: 'slate',
-  sky: 'slate',
-  cyan: 'slate',
-  mint: 'sage',
-  teal: 'sage',
-  jade: 'sage',
-  green: 'sage',
-  grass: 'olive',
-  lime: 'olive',
-  yellow: 'sand',
-  amber: 'sand',
-  orange: 'sand',
-  brown: 'sand',
-  gold: 'sand',
-  bronze: 'sand',
-};
-
-// type SemanticPaletteName = 'artifact' | 'entity' | 'concept' | 'error' | 'success' | 'info';
-
-type ForegroundColor = 'white' | 'black';
-type LightDarkColorString = `light-dark(${string}, ${string})`;
-type ScaleStep = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+const scaleSteps = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+type ScaleStep = (typeof scaleSteps)[number];
 type RadixScale = Record<string, string>;
-type ColorToken = { value: string };
-
-type PaletteScale = {
-  1: LightDarkColorString;
-  2: LightDarkColorString;
-  3: LightDarkColorString;
-  4: LightDarkColorString;
-  5: LightDarkColorString;
-  6: LightDarkColorString;
-  7: LightDarkColorString;
-  8: LightDarkColorString;
-  9: LightDarkColorString;
-  10: LightDarkColorString;
-  11: LightDarkColorString;
-  12: LightDarkColorString;
-  contrast: string;
-};
-
-type SemanticPaletteScale = {
-  display: string;
-  primary: string;
-  secondary: string;
-  muted: string;
-  symbol: string;
-  accent: string;
-  accentActive: string;
-  background: string;
-  surface: string;
-  container: string;
-  float: string;
-  divider: string;
-  border: string;
-  edge: string;
-  focus: string;
-  mist: string;
-  splash: string;
-  flood: string;
-  main: string;
-  mainActive: string;
-  mainContrast: string;
-};
-
-export const semanticPaletteNames = [
-  'artifact',
-  'entity',
-  'concept',
-  'error',
-  'success',
-  'info',
-] as const;
-export type SemanticPaletteName = (typeof semanticPaletteNames)[number];
-
-export const semanticColorNames = [
-  'display',
-  'primary',
-  'secondary',
-  'muted',
-  'symbol',
-  'accent',
-  'accentActive',
-  'background',
-  'surface',
-  'container',
-  'float',
-  'divider',
-  'border',
-  'edge',
-  'focus',
-  'mist',
-  'splash',
-  'flood',
-  'main',
-  'mainActive',
-  'mainContrast',
-] as const satisfies readonly (keyof SemanticPaletteScale)[];
-
-const lightDark = (light: string, dark: string): LightDarkColorString =>
-  `light-dark(${light}, ${dark})`;
 
 const getRadixScaleStep = (scale: RadixScale, step: ScaleStep): string => {
   const match = Object.entries(scale).find(([key]) => key.match(/\d+$/)?.[0] === `${step}`);
@@ -186,129 +63,167 @@ const getRadixScaleStep = (scale: RadixScale, step: ScaleStep): string => {
   return match[1];
 };
 
-export const zipRadixScale = (
+const zipRadixScale = (
   lightScale: RadixScale,
   darkScale: RadixScale,
-  foregroundColor?: ForegroundColor
-): PaletteScale => ({
-  1: lightDark(getRadixScaleStep(lightScale, 1), getRadixScaleStep(darkScale, 1)),
-  2: lightDark(getRadixScaleStep(lightScale, 2), getRadixScaleStep(darkScale, 2)),
-  3: lightDark(getRadixScaleStep(lightScale, 3), getRadixScaleStep(darkScale, 3)),
-  4: lightDark(getRadixScaleStep(lightScale, 4), getRadixScaleStep(darkScale, 4)),
-  5: lightDark(getRadixScaleStep(lightScale, 5), getRadixScaleStep(darkScale, 5)),
-  6: lightDark(getRadixScaleStep(lightScale, 6), getRadixScaleStep(darkScale, 6)),
-  7: lightDark(getRadixScaleStep(lightScale, 7), getRadixScaleStep(darkScale, 7)),
-  8: lightDark(getRadixScaleStep(lightScale, 8), getRadixScaleStep(darkScale, 8)),
-  9: lightDark(getRadixScaleStep(lightScale, 9), getRadixScaleStep(darkScale, 9)),
-  10: lightDark(getRadixScaleStep(lightScale, 10), getRadixScaleStep(darkScale, 10)),
-  11: lightDark(getRadixScaleStep(lightScale, 11), getRadixScaleStep(darkScale, 11)),
-  12: lightDark(getRadixScaleStep(lightScale, 12), getRadixScaleStep(darkScale, 12)),
-  contrast: foregroundColor === 'black' ? BLACK : WHITE, // Default to white contrast text for most palettes. Only Sky, Mint, Lime, Yellow, and Amber are designed for dark foreground text.
+  foregroundColor: 'white' | 'black' = 'white' // Only Sky, Mint, Lime, Yellow, and Amber are designed for dark foreground text.
+) => ({
+  ...Object.fromEntries(
+    scaleSteps.map((step) => [
+      step,
+      { value: lightDark(getRadixScaleStep(lightScale, step), getRadixScaleStep(darkScale, step)) },
+    ])
+  ),
+  contrast: { value: foregroundColor === 'black' ? BLACK : WHITE },
 });
 
-const toColorTokens = (
-  scale: PaletteScale
-): Record<ScaleStep, ColorToken> & { contrast: { value: string } } => ({
-  1: { value: scale[1] },
-  2: { value: scale[2] },
-  3: { value: scale[3] },
-  4: { value: scale[4] },
-  5: { value: scale[5] },
-  6: { value: scale[6] },
-  7: { value: scale[7] },
-  8: { value: scale[8] },
-  9: { value: scale[9] },
-  10: { value: scale[10] },
-  11: { value: scale[11] },
-  12: { value: scale[12] },
-  contrast: { value: scale.contrast },
+const hues = {
+  amber: zipRadixScale(amber, amberDark, 'black'),
+  bronze: zipRadixScale(bronze, bronzeDark),
+  gold: zipRadixScale(gold, goldDark),
+  grass: zipRadixScale(grass, grassDark),
+  iris: zipRadixScale(iris, irisDark),
+  mauve: zipRadixScale(mauve, mauveDark),
+  olive: zipRadixScale(olive, oliveDark),
+  sand: zipRadixScale(sand, sandDark),
+  slate: zipRadixScale(slate, slateDark),
+  tomato: zipRadixScale(tomato, tomatoDark),
+};
+type HueName = keyof typeof hues;
+
+export const palettes = {
+  artifact: { chromatic: 'gold', neutral: 'sand' },
+  concept: { chromatic: 'amber', neutral: 'sand' },
+  entity: { chromatic: 'bronze', neutral: 'sand' },
+  error: { chromatic: 'tomato', neutral: 'mauve' },
+  info: { chromatic: 'iris', neutral: 'slate' },
+  success: { chromatic: 'grass', neutral: 'olive' },
+} as const satisfies Record<string, { chromatic: HueName; neutral: HueName }>;
+export type PaletteName = keyof typeof palettes;
+
+type SemanticVariants = { neutral: string; chromatic: string };
+
+const semanticColors = {
+  display: {
+    neutral: 'color-mix(in oklch, var(--neu-12), var(--colors-mode-contrast))',
+    chromatic:
+      'light-dark(var(--clr-12), color-mix(in oklch, var(--clr-12), var(--colors-mode-contrast)))',
+  },
+  primary: {
+    neutral: 'var(--neu-12)',
+    chromatic: 'light-dark(color-mix(in oklch, var(--clr-11), var(--neu-12)), var(--clr-12))',
+  },
+  secondary: {
+    neutral: 'var(--neu-11)',
+    chromatic:
+      'light-dark(color-mix(in oklch, var(--clr-9), var(--neu-12)), color-mix(in oklch, var(--clr-12), var(--neu-9)))',
+  },
+  muted: {
+    neutral: 'color-mix(in oklch, var(--neu-9), var(--neu-10))',
+    chromatic: 'color-mix(in oklch, var(--clr-9) 75%, var(--neu-9))',
+  },
+  symbol: {
+    neutral: 'color-mix(in oklch, var(--neu-11) 75%, var(--clr-10))',
+    chromatic: 'color-mix(in oklch, var(--clr-11) 75%, var(--neu-10))',
+  },
+  accent: {
+    neutral: 'color-mix(in oklch, var(--neu-11), var(--clr-11))',
+    chromatic: 'var(--clr-11)',
+  },
+  accentActive: {
+    neutral: 'color-mix(in oklch, var(--neu-12), var(--clr-11))',
+    chromatic: 'color-mix(in oklch, var(--clr-12), var(--clr-11))',
+  },
+  background: {
+    neutral: 'light-dark(var(--neu-2), var(--neu-1))',
+    chromatic: 'light-dark(color-mix(in oklch, var(--clr-1), var(--clr-2)), var(--clr-1))',
+  },
+  surface: {
+    neutral: 'light-dark(var(--neu-1), var(--neu-2))',
+    chromatic: 'light-dark(color-mix(in oklch, var(--clr-2), var(--clr-3)), var(--clr-2))',
+  },
+  container: {
+    neutral: 'color-mix(in oklch, var(--neu-2), var(--neu-3))',
+    chromatic: 'light-dark(color-mix(in oklch, var(--clr-3), var(--clr-4)), var(--clr-3))',
+  },
+  float: {
+    neutral: `light-dark(${WHITE}, var(--neu-3))`,
+    chromatic: 'light-dark(color-mix(in oklch, var(--clr-3), var(--clr-4)), var(--clr-3))',
+  },
+  divider: {
+    neutral: 'light-dark(var(--neu-6), var(--neu-5))',
+    chromatic: 'light-dark(var(--clr-6), var(--clr-4))',
+  },
+  border: {
+    neutral: 'light-dark(var(--neu-7), var(--neu-6))',
+    chromatic: 'light-dark(var(--clr-7), var(--clr-5))',
+  },
+  edge: {
+    neutral: 'light-dark(var(--neu-8), var(--neu-7))',
+    chromatic: 'light-dark(var(--clr-8), var(--clr-6))',
+  },
+  focus: {
+    neutral: 'color-mix(in oklch, var(--neu-9) 75%, var(--clr-9))',
+    chromatic: 'light-dark(var(--clr-9), var(--clr-8))',
+  },
+  mist: {
+    neutral: 'color-mix(in oklch, var(--neu-9) 3%, transparent)',
+    chromatic: 'color-mix(in oklch, var(--clr-9) 3%, transparent)',
+  },
+  splash: {
+    neutral: 'color-mix(in oklch, var(--neu-9) 6%, transparent)',
+    chromatic: 'color-mix(in oklch, var(--clr-9) 6%, transparent)',
+  },
+  flood: {
+    neutral: 'color-mix(in oklch, var(--neu-9) 9%, transparent)',
+    chromatic: 'color-mix(in oklch, var(--clr-9) 9%, transparent)',
+  },
+  main: {
+    neutral: 'var(--neu-9)',
+    chromatic: 'var(--clr-9)',
+  },
+  mainActive: {
+    neutral: 'var(--neu-10)',
+    chromatic: 'var(--clr-10)',
+  },
+  mainContrast: {
+    neutral: 'var(--neu-contrast)',
+    chromatic: 'var(--clr-contrast)',
+  },
+} as const satisfies Record<string, SemanticVariants>;
+
+const blend = ({ neutral, chromatic }: SemanticVariants) =>
+  `color-mix(in oklch, ${neutral}, ${chromatic} var(--chroma, 0%))`;
+
+export type CssVarDeclarations = Record<`--${string}`, string>;
+
+const toCssVarName = (value: string) =>
+  value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+
+const semanticColorDeclarations = Object.fromEntries(
+  Object.entries(semanticColors).map(([name, variants]) => [
+    `--colors-${toCssVarName(name)}`,
+    blend(variants),
+  ])
+);
+
+const rampDeclarations = (prefix: 'clr' | 'neu', hue: HueName) => ({
+  ...Object.fromEntries(
+    scaleSteps.map((step) => [`--${prefix}-${step}`, `var(--colors-${hue}-${step})`])
+  ),
+  [`--${prefix}-contrast`]: `var(--colors-${hue}-contrast)`,
 });
 
-type SemanticPalettePair = { neutral: SemanticPaletteScale; chromatic: SemanticPaletteScale };
-const toSemanticPalettePair = (chromaticScale: ChromaticPaletteName): SemanticPalettePair => {
-  const associatedNeutral = neutralAssociations[chromaticScale];
-  const neu = associatedNeutral;
-  const clr = chromaticScale;
-  return {
-    neutral: {
-      display: `color-mix(in oklch, {colors.${neu}.12}, {colors.modeContrast})`,
-      primary: `{colors.${neu}.12}`,
-      secondary: `{colors.${neu}.11}`,
-      muted: `color-mix(in oklch, {colors.${neu}.9}, {colors.${neu}.10})`,
-      symbol: `color-mix(in oklch, {colors.${neu}.11} 75%, {colors.${clr}.10})`,
-      accent: `color-mix(in oklch, {colors.${neu}.11}, {colors.${clr}.11})`,
-      accentActive: `color-mix(in oklch, {colors.${neu}.12}, {colors.${clr}.11})`,
-      background: `light-dark({colors.${neu}.2}, {colors.${neu}.1})`,
-      surface: `light-dark({colors.${neu}.1}, {colors.${neu}.2})`,
-      container: `color-mix(in oklch, {colors.${neu}.2}, {colors.${neu}.3})`,
-      float: `light-dark(${WHITE}, {colors.${neu}.3})`,
-      divider: `light-dark({colors.${neu}.6}, {colors.${neu}.5})`,
-      border: `light-dark({colors.${neu}.7}, {colors.${neu}.6})`,
-      edge: `light-dark({colors.${neu}.8}, {colors.${neu}.7})`,
-      focus: `color-mix(in oklch, {colors.${neu}.9} 75%, {colors.${clr}.9})`,
-      mist: `color-mix(in oklch, {colors.${neu}.9} 3%, transparent)`,
-      splash: `color-mix(in oklch, {colors.${neu}.9} 6%, transparent)`,
-      flood: `color-mix(in oklch, {colors.${neu}.9} 9%, transparent)`,
-      main: `{colors.${neu}.9}`,
-      mainActive: `{colors.${neu}.10}`,
-      mainContrast: `{colors.${neu}.contrast}`,
-    },
-    chromatic: {
-      display: `light-dark({colors.${clr}.12}, color-mix(in oklch, {colors.${clr}.12}, {colors.modeContrast}))`,
-      primary: `light-dark(color-mix(in oklch, {colors.${clr}.11}, {colors.${neu}.12}), {colors.${clr}.12})`,
-      secondary: `light-dark(color-mix(in oklch, {colors.${clr}.9}, {colors.${neu}.12}), color-mix(in oklch, {colors.${clr}.12}, {colors.${neu}.9}))`,
-      muted: `color-mix(in oklch, {colors.${clr}.9} 75%, {colors.${neu}.9})`,
-      symbol: `color-mix(in oklch, {colors.${clr}.11} 75%, {colors.${neu}.10})`,
-      accent: `{colors.${clr}.11}`,
-      accentActive: `color-mix(in oklch, {colors.${clr}.12}, {colors.${clr}.11})`,
-      background: `light-dark(color-mix(in oklch, {colors.${clr}.1}, {colors.${clr}.2}), {colors.${clr}.1})`,
-      surface: `light-dark(color-mix(in oklch, {colors.${clr}.2}, {colors.${clr}.3}), {colors.${clr}.2})`,
-      container: `light-dark(color-mix(in oklch, {colors.${clr}.3}, {colors.${clr}.4}), {colors.${clr}.3})`,
-      float: `light-dark(color-mix(in oklch, {colors.${clr}.3}, {colors.${clr}.4}), {colors.${clr}.3})`,
-      divider: `light-dark({colors.${clr}.6}, {colors.${clr}.4})`,
-      border: `light-dark({colors.${clr}.7}, {colors.${clr}.5})`,
-      edge: `light-dark({colors.${clr}.8}, {colors.${clr}.6})`,
-      focus: `light-dark({colors.${clr}.9}, {colors.${clr}.8})`,
-      mist: `color-mix(in oklch, {colors.${clr}.9} 3%, transparent)`,
-      splash: `color-mix(in oklch, {colors.${clr}.9} 6%, transparent)`,
-      flood: `color-mix(in oklch, {colors.${clr}.9} 9%, transparent)`,
-      main: `{colors.${clr}.9}`,
-      mainActive: `{colors.${clr}.10}`,
-      mainContrast: `{colors.${clr}.contrast}`,
-    },
-  };
-};
+export const paletteDeclarations = (palette: PaletteName): CssVarDeclarations => ({
+  ...rampDeclarations('clr', palettes[palette].chromatic),
+  ...rampDeclarations('neu', palettes[palette].neutral),
+  ...semanticColorDeclarations,
+});
 
-const toSemanticPaletteTokens = (pair: SemanticPalettePair) => {
-  const keys = Object.keys(pair.neutral) as (keyof SemanticPaletteScale)[];
-  return keys.reduce(
-    (tokens, key) => {
-      tokens[key] = {
-        value: {
-          base: pair.neutral[key],
-          _chromatic: pair.chromatic[key],
-        },
-      };
-      return tokens;
-    },
-    {} as Record<keyof SemanticPaletteScale, { value: { base: string; _chromatic: string } }>
-  );
-};
-
-const mauveScale = zipRadixScale(mauve, mauveDark);
-const tomatoScale = zipRadixScale(tomato, tomatoDark);
-const sandScale = zipRadixScale(sand, sandDark);
-const sageScale = zipRadixScale(sage, sageDark);
-const slateScale = zipRadixScale(slate, slateDark);
-const oliveScale = zipRadixScale(olive, oliveDark);
-const tealScale = zipRadixScale(teal, tealDark);
-const irisScale = zipRadixScale(iris, irisDark);
-const amberScale = zipRadixScale(amber, amberDark, 'black');
-const grassScale = zipRadixScale(grass, grassDark);
-const goldScale = zipRadixScale(gold, goldDark);
-const bronzeScale = zipRadixScale(bronze, bronzeDark);
-const brownScale = zipRadixScale(brown, brownDark);
-const grayScale = zipRadixScale(gray, grayDark);
+export const chromaticDeclarations = (chromatic: boolean): CssVarDeclarations => ({
+  '--chroma': chromatic ? '100%' : '0%',
+  ...semanticColorDeclarations,
+});
 
 export const colors = defineTokens.colors({
   transparent: { value: 'transparent' },
@@ -316,48 +231,8 @@ export const colors = defineTokens.colors({
   white: { value: WHITE },
   black: { value: BLACK },
   modeContrast: { value: lightDark(BLACK, WHITE) },
-  mauve: toColorTokens(mauveScale),
-  tomato: toColorTokens(tomatoScale),
-  sand: toColorTokens(sandScale),
-  sage: toColorTokens(sageScale),
-  slate: toColorTokens(slateScale),
-  olive: toColorTokens(oliveScale),
-  teal: toColorTokens(tealScale),
-  iris: toColorTokens(irisScale),
-  amber: toColorTokens(amberScale),
-  grass: toColorTokens(grassScale),
-  gold: toColorTokens(goldScale),
-  bronze: toColorTokens(bronzeScale),
-  brown: toColorTokens(brownScale),
-  gray: toColorTokens(grayScale),
-});
-
-export const semanticColors = defineSemanticTokens.colors({
-  artifact: toSemanticPaletteTokens(toSemanticPalettePair('gold')),
-  entity: toSemanticPaletteTokens(toSemanticPalettePair('bronze')),
-  concept: toSemanticPaletteTokens(toSemanticPalettePair('amber')),
-  error: toSemanticPaletteTokens(toSemanticPalettePair('tomato')),
-  success: toSemanticPaletteTokens(toSemanticPalettePair('grass')),
-  info: toSemanticPaletteTokens(toSemanticPalettePair('iris')),
-  display: { value: 'var(--colors-color-palette-display)' },
-  primary: { value: 'var(--colors-color-palette-primary)' },
-  secondary: { value: 'var(--colors-color-palette-secondary)' },
-  muted: { value: 'var(--colors-color-palette-muted)' },
-  symbol: { value: 'var(--colors-color-palette-symbol)' },
-  accent: { value: 'var(--colors-color-palette-accent)' },
-  accentActive: { value: 'var(--colors-color-palette-accent-active)' },
-  background: { value: 'var(--colors-color-palette-background)' },
-  surface: { value: 'var(--colors-color-palette-surface)' },
-  container: { value: 'var(--colors-color-palette-container)' },
-  float: { value: 'var(--colors-color-palette-float)' },
-  divider: { value: 'var(--colors-color-palette-divider)' },
-  border: { value: 'var(--colors-color-palette-border)' },
-  edge: { value: 'var(--colors-color-palette-edge)' },
-  focus: { value: 'var(--colors-color-palette-focus)' },
-  mist: { value: 'var(--colors-color-palette-mist)' },
-  splash: { value: 'var(--colors-color-palette-splash)' },
-  flood: { value: 'var(--colors-color-palette-flood)' },
-  main: { value: 'var(--colors-color-palette-main)' },
-  mainActive: { value: 'var(--colors-color-palette-main-active)' },
-  mainContrast: { value: 'var(--colors-color-palette-main-contrast)' },
+  ...hues,
+  ...Object.fromEntries(
+    Object.entries(semanticColors).map(([name, variants]) => [name, { value: blend(variants) }])
+  ),
 });

--- a/src/app/styles/conditions.ts
+++ b/src/app/styles/conditions.ts
@@ -15,10 +15,6 @@ export const conditionsPreset = definePreset({
       selected: '&:is([aria-selected=true], [data-selected]:not([data-selected=false]))',
       dark: ':where([data-color-scheme="dark"], [data-dark], .dark) &',
       light: ':where([data-color-scheme="light"], [data-light], .light) &',
-      neutral:
-        '&[data-neutral], &.layerStyle_neutral, :where([data-neutral], [data-chroma="neutral"], .neutral, .layerStyle_neutral) &',
-      chromatic:
-        '&[data-chromatic], &.layerStyle_chromatic, :where([data-chromatic], .layerStyle_chromatic) &',
       childIcon: '& :where(svg, .icon, .lucide)',
       sideBottom: '&[data-side=bottom]',
       sideTop: '&[data-side=top]',

--- a/src/app/styles/globals.ts
+++ b/src/app/styles/globals.ts
@@ -1,25 +1,23 @@
 import { defineGlobalStyles } from '@pandacss/dev';
-import { semanticColorNames, semanticPaletteNames } from './colors';
+import { palettes } from './colors';
 
-const toCssVarName = (value: string) =>
-  value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-
-const paletteAliasScopes = Object.fromEntries(
-  semanticPaletteNames.map((palette) => [
-    `@scope (.color-palette_${palette})`,
-    {
-      ':scope, :scope *': Object.fromEntries(
-        semanticColorNames.map((token) => {
-          const cssVarName = toCssVarName(token);
-          return [`--colors-${cssVarName}`, `var(--colors-${palette}-${cssVarName})`];
-        })
-      ),
-    },
-  ])
-);
+const boundaryClasses = [
+  ...Object.keys(palettes).map((palette) => `.palette_${palette}`),
+  '.chromatic_true',
+  '.chromatic_false',
+  '.mode_normal',
+  '.mode_inverted',
+  '.mode_light',
+  '.mode_dark',
+];
 
 export const globalStyles = defineGlobalStyles({
-  ...paletteAliasScopes,
+  // Theme boundary elements re-assert the default text color so plain
+  // inherited text re-resolves against the new context. This lives in the
+  // base layer so any explicit color — recipe or atomic — wins the cascade.
+  [`:where(${boundaryClasses.join(', ')})`]: {
+    color: 'var(--colors-primary)',
+  },
   html: {
     '--global-font-body': 'fonts.sans',
     '--global-font-mono': 'fonts.mono',

--- a/src/app/styles/plugins.ts
+++ b/src/app/styles/plugins.ts
@@ -1,5 +1,7 @@
 import type { PropertyConfig } from '@pandacss/dev';
 import { defineUtility } from '@pandacss/dev';
+import { borderDeclarations } from './borders';
+import { chromaticDeclarations, paletteDeclarations, palettes, type PaletteName } from './colors';
 
 // ---------------------------------------------------------------------------
 // Composable enter/exit animation utilities
@@ -166,6 +168,41 @@ export const translateCenterUtility = defineUtility({
   },
 });
 
+// ---------------------------------------------------------------------------
+// Theme boundary utilities
+//
+// `palette`, `chromatic`, and `mode` each mark a theme boundary: they change
+// an inherited input (ramp aliases, --chroma, color-scheme) and re-declare the
+// semantic color formulas so the subtree re-resolves against the new context
+// (see colors.ts). A base-layer rule in globals.ts re-asserts the default text
+// color on boundary elements, so plain inherited text adapts across the
+// boundary while explicit colors — recipe or atomic — still win the cascade.
+// ---------------------------------------------------------------------------
+
+const isPaletteName = (value: unknown): value is PaletteName =>
+  typeof value === 'string' && value in palettes;
+
+const paletteUtility = defineUtility({
+  className: 'palette',
+  values: Object.keys(palettes),
+  transform: (value) => {
+    if (!isPaletteName(value)) return {};
+    return {
+      ...paletteDeclarations(value),
+      ...borderDeclarations,
+    };
+  },
+});
+
+const chromaticUtility = defineUtility({
+  className: 'chromatic',
+  values: { type: 'boolean' },
+  transform: (value) => ({
+    ...chromaticDeclarations(value === true),
+    ...borderDeclarations,
+  }),
+});
+
 // Usage: `className={css({ mode: 'inverted' })}`
 export const modeUtility = defineUtility({
   className: 'mode',
@@ -209,5 +246,7 @@ export const utilities: Record<string, PropertyConfig> = {
   slideOutY: slideOutYUtility,
   debug: debugUtility,
   translateCenter: translateCenterUtility,
+  chromatic: chromaticUtility,
   mode: modeUtility,
+  palette: paletteUtility,
 };


### PR DESCRIPTION
The color system stacks three overlapping mechanisms: Panda's built-in `colorPalette` variable indirection, an `@scope` layer that re-declares every semantic alias on every element of a palette subtree, and a `[data-chromatic]` token-condition block. Parts of it are silently broken: `colorPalette` inside recipes never resolves, and chromaticity can't be un-set below a chromatic ancestor.

Replaces all of it with a single engine modeled on barnsworthburning's triptych system. Each semantic color token becomes one formula, `color-mix(in oklch, <neutral>, <chromatic> var(--chroma))`, over inherited ramp aliases, and three typed utilities set the theme axes anywhere in the tree:

- `palette` aliases a chromatic hue ramp and its associated neutral ramp to `--clr-*` / `--neu-*`
- `chromatic` flips `--chroma` between 100% and 0%
- `mode` sets `color-scheme`, which every `light-dark()` pair resolves against per element

Each boundary re-declares the token formulas so its subtree re-resolves against the new context, and a base-layer rule re-asserts `color: primary` on boundary elements so plain inherited text adapts while explicit colors, recipe or atomic, still win the cascade. Consumers are untouched: `color: 'primary'` works as before, and only boundary-setting call sites migrate. Also fixes border tokens baking at `:root` and ignoring theme boundaries, and drops the unused sage, teal, gray, and brown hue scales.