### PR TITLE
Refresh similar records after link mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/app/lib/hooks/link-mutations.ts
+++ b/src/app/lib/hooks/link-mutations.ts
@@ -71,17 +71,6 @@ export function useUpsertLink() {
         };
       });
 
-      // Use Set for O(1) lookups when filtering
-      const idSet = new Set([sourceId, targetId]);
-      utils.search.byRecordId.setData({ id: sourceId, limit: 10 }, (prev) => {
-        if (!prev) return undefined;
-        return prev.filter((r) => !idSet.has(r.id));
-      });
-      utils.search.byRecordId.setData({ id: targetId, limit: 10 }, (prev) => {
-        if (!prev) return undefined;
-        return prev.filter((r) => !idSet.has(r.id));
-      });
-
       return { prevSource, prevTarget };
     },
     onSuccess: (row) => {
@@ -89,6 +78,9 @@ export function useUpsertLink() {
 
       void utils.links.listForRecord.invalidate({ id: sourceId });
       void utils.links.listForRecord.invalidate({ id: targetId });
+
+      void utils.search.byRecordId.invalidate({ id: sourceId });
+      void utils.search.byRecordId.invalidate({ id: targetId });
 
       void utils.records.tree.invalidate({ id: sourceId });
       void utils.records.tree.invalidate({ id: targetId });

--- a/src/server/lib/constants.ts
+++ b/src/server/lib/constants.ts
@@ -1,4 +1,4 @@
-import { cosineDistance, sql, type Column, type SQL } from 'drizzle-orm';
+import { sql, type Column, type SQL } from 'drizzle-orm';
 
 export const SIMILARITY_THRESHOLD = 0.8; // Cosine similarity floor (higher = stricter)
 /** Max same-URL records pinned as duplicate candidates; larger clusters are junk (platform root URLs), not identity signals. */


### PR DESCRIPTION
Creating a link stopped refreshing the Similar Records section: the `search.byRecordId` invalidation lived in the client-side embed hook that #134 (AI pipeline and search ranking rebuild) deleted when embedding regeneration moved server-side. Invalidates the query for both link endpoints on upsert, matching what link deletion already does, so a newly linked record drops out of the list immediately. Also removes an optimistic cache update that wrote to a `limit: 10` key no query reads, and an unused `cosineDistance` import left behind by the same PR.