### PR TITLE
Parallelize integration syncs and remove fixed rate-limit sleeps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
     },
     "packages/hozo": {
       "name": "@aias/hozo",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "drizzle-kit": "1.0.0-rc.4",
         "drizzle-orm": "1.0.0-rc.4",

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@base-ui/react": "~1.6.0",
         "@libsql/client": "~0.17.4",
+        "@octokit/plugin-throttling": "~11.0.3",
         "@octokit/request-error": "~7.1.0",
         "@octokit/rest": "~22.0.1",
         "@radix-ui/colors": "~3.0.0",
@@ -297,6 +298,8 @@
     "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
 
     "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/plugin-throttling": ["@octokit/plugin-throttling@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": "^7.0.0" } }, "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg=="],
 
     "@octokit/request": ["@octokit/request@10.0.9", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A=="],
 
@@ -815,6 +818,8 @@
     "bippy": ["bippy@0.5.40", "", { "peerDependencies": { "react": ">=17.0.1" } }, "sha512-3QPSDG5tgd7FCIkcKsUqmbGdlHxBxP7II5drXPNp1I0rpA9+4+/VjQOigDTbzeqTi6Xkaf1Dq7x4E8vbOuwOkA=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",
@@ -43,6 +43,7 @@
   "dependencies": {
     "@base-ui/react": "~1.6.0",
     "@libsql/client": "~0.17.4",
+    "@octokit/plugin-throttling": "~11.0.3",
     "@octokit/request-error": "~7.1.0",
     "@octokit/rest": "~22.0.1",
     "@radix-ui/colors": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "format:check": "oxfmt --check",
     "lint": "oxlint --fix .",
     "lint:check": "oxlint .",
+    "publish:hozo": "bun publish --cwd packages/hozo",
     "rcr": "bun src/server/cli/rcr/index.ts",
     "start": "bun run server.ts",
     "stylegen": "rm -rf src/app/styled-system && panda codegen && panda cssgen",

--- a/packages/hozo/package.json
+++ b/packages/hozo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/hozo",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared schema, relations, and validation for Red Cliff Record",
   "license": "MIT",
   "files": [
@@ -23,7 +23,7 @@
   "scripts": {
     "dev:watch": "tsup src/index.ts --dts --format esm --sourcemap --watch",
     "lint": "oxlint --fix --type-aware . && tsgo --noEmit",
-    "prepack": "tsup src/index.ts --dts --format esm --sourcemap --clean",
+    "prepack": "bunx --bun tsup src/index.ts --dts --format esm --sourcemap --clean",
     "test": "bun test"
   },
   "devDependencies": {

--- a/src/server/cli/rcr/commands/sync.ts
+++ b/src/server/cli/rcr/commands/sync.ts
@@ -12,6 +12,7 @@ import { syncCodexHistory } from '@/server/integrations/agents/sync-codex';
 import { syncCursorHistory } from '@/server/integrations/agents/sync-cursor';
 import { syncAirtableData } from '@/server/integrations/airtable/sync';
 import { syncAllBrowserData } from '@/server/integrations/browser-history/sync-all';
+import { withBufferedLogs } from '@/server/integrations/common/buffered-logs';
 import { syncFeedbin } from '@/server/integrations/feedbin/sync';
 import { syncGitHubData } from '@/server/integrations/github/sync';
 import { syncRaindropData } from '@/server/integrations/raindrop/sync';
@@ -184,9 +185,14 @@ async function runSingleSync(integration: IntegrationName, options: SyncOptions)
     }
     case 'agents': {
       const sessionLimit = 5;
-      await syncClaudeHistory(debug, { sessionLimit });
-      await syncCodexHistory(debug, { sessionLimit });
-      await syncCursorHistory(debug, { sessionLimit });
+      const settled = await Promise.allSettled([
+        withBufferedLogs(() => syncClaudeHistory(debug, { sessionLimit })),
+        withBufferedLogs(() => syncCodexHistory(debug, { sessionLimit })),
+        withBufferedLogs(() => syncCursorHistory(debug, { sessionLimit })),
+      ]);
+      for (const result of settled) {
+        if (result.status === 'rejected') throw result.reason;
+      }
       return {
         integration,
         success: true,
@@ -208,22 +214,25 @@ async function runDailySync(options: SyncOptions) {
     'github',
   ];
 
-  const results: Array<{ step: string; success: boolean; error?: string }> = [];
   const startTime = performance.now();
 
-  // Run external syncs
-  for (const integration of dailyIntegrations) {
-    try {
-      await runSingleSync(integration, options);
-      results.push({ step: integration, success: true });
-    } catch (e) {
-      results.push({
-        step: integration,
-        success: false,
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
-  }
+  // Run external syncs concurrently — they hit disjoint APIs. Each
+  // integration's logs are buffered and emitted as one contiguous block when
+  // it finishes, so concurrent output never interleaves.
+  const results: Array<{ step: string; success: boolean; error?: string }> = await Promise.all(
+    dailyIntegrations.map(async (integration) => {
+      try {
+        await withBufferedLogs(() => runSingleSync(integration, options));
+        return { step: integration, success: true };
+      } catch (e) {
+        return {
+          step: integration,
+          success: false,
+          error: e instanceof Error ? e.message : String(e),
+        };
+      }
+    })
+  );
 
   // Run enrichments once at the end
   try {

--- a/src/server/integrations/adobe/map.ts
+++ b/src/server/integrations/adobe/map.ts
@@ -9,8 +9,12 @@ import {
 import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { getMediaInsertData, uploadMediaToR2 } from '@/server/lib/media';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { getRecordId, linkRecords } from '../common/db-helpers';
 import { createIntegrationLogger } from '../common/logging';
+
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 
 const logger = createIntegrationLogger('adobe', 'map');
 
@@ -51,23 +55,28 @@ export const resetMediaCaptionsForLightroomImages = async () => {
   logger.info(`Found ${images.length} Lightroom images with linked records`);
 
   let updatedCount = 0;
-  for (const image of images) {
-    if (!image.recordId) continue;
+  const captionResults = await runConcurrentPool({
+    items: images,
+    concurrency: DB_CONCURRENCY,
+    async worker(image) {
+      if (!image.recordId) return;
 
-    const description = generateImageDescription(image);
+      const description = generateImageDescription(image);
 
-    // Update the record's mediaCaption
-    await db
-      .update(records)
-      .set({
-        mediaCaption: description,
-        recordUpdatedAt: new Date(),
-      })
-      .where(eq(records.id, image.recordId));
+      // Update the record's mediaCaption
+      await db
+        .update(records)
+        .set({
+          mediaCaption: description,
+          recordUpdatedAt: new Date(),
+        })
+        .where(eq(records.id, image.recordId));
 
-    updatedCount++;
-    logger.info(`Updated caption for record ${image.recordId} (${image.fileName})`);
-  }
+      updatedCount++;
+      logger.info(`Updated caption for record ${image.recordId} (${image.fileName})`);
+    },
+  });
+  throwPoolFailures(captionResults, 'Lightroom media caption reset', images.length);
 
   logger.complete(`Updated captions for ${updatedCount} records`);
 };
@@ -152,93 +161,101 @@ export const createMediaFromLightroomImages = async () => {
 
   logger.info(`Found ${unmappedImages.length} unmapped Lightroom images`);
 
-  for (const image of unmappedImages) {
-    let mediaId: number | null = image.media?.id ?? null;
-    let recordId: number | null = image.record?.id ?? null;
+  let processed = 0;
+  const imageResults = await runConcurrentPool({
+    items: unmappedImages,
+    concurrency: DB_CONCURRENCY,
+    async worker(image) {
+      let mediaId: number | null = image.media?.id ?? null;
+      let recordId: number | null = image.record?.id ?? null;
 
-    // Create media if needed
-    if (!mediaId) {
-      logger.info(`Creating media for ${image.fileName}`);
-      const newMediaDefaults = await mapLightroomImageToMedia(image);
+      // Create media if needed
+      if (!mediaId) {
+        logger.info(`Creating media for ${image.fileName}`);
+        const newMediaDefaults = await mapLightroomImageToMedia(image);
 
-      if (!newMediaDefaults) {
-        logger.error(`Failed to create media for ${image.fileName}`);
-        continue;
+        if (!newMediaDefaults) {
+          logger.error(`Failed to create media for ${image.fileName}`);
+          return;
+        }
+
+        // Update the url2048 to the new url so subsequent runs don't try to upload again
+        await db
+          .update(lightroomImages)
+          .set({ url2048: newMediaDefaults.url })
+          .where(eq(lightroomImages.id, image.id));
+
+        const [newMedia] = await db
+          .insert(media)
+          .values(newMediaDefaults)
+          .onConflictDoUpdate({
+            target: media.id,
+            set: {
+              recordUpdatedAt: new Date(),
+            },
+          })
+          .returning({ id: media.id });
+
+        if (!newMedia) {
+          throw new Error('Failed to create media');
+        }
+
+        mediaId = newMedia.id;
+        await db.update(lightroomImages).set({ mediaId }).where(eq(lightroomImages.id, image.id));
+
+        logger.info(`Created media ${mediaId} for ${image.fileName}`);
       }
 
-      // Update the url2048 to the new url so subsequent runs don't try to upload again
-      await db
-        .update(lightroomImages)
-        .set({ url2048: newMediaDefaults.url })
-        .where(eq(lightroomImages.id, image.id));
+      // Create record if needed
+      if (!image.record) {
+        logger.info(`Creating record for ${image.fileName}`);
+        const newRecordDefaults = mapLightroomImageToRecord(image);
 
-      const [newMedia] = await db
-        .insert(media)
-        .values(newMediaDefaults)
-        .onConflictDoUpdate({
-          target: media.id,
-          set: {
-            recordUpdatedAt: new Date(),
-          },
-        })
-        .returning({ id: media.id });
+        const [newRecord] = await db
+          .insert(records)
+          .values(newRecordDefaults)
+          .onConflictDoUpdate({
+            target: records.id,
+            set: {
+              recordUpdatedAt: new Date(),
+            },
+          })
+          .returning({ id: records.id });
 
-      if (!newMedia) {
-        throw new Error('Failed to create media');
+        if (!newRecord) {
+          throw new Error('Failed to create record');
+        }
+
+        recordId = newRecord.id;
+        await db.update(lightroomImages).set({ recordId }).where(eq(lightroomImages.id, image.id));
+
+        // Link to author if found
+        const me = await getRecordId('nick-trombley', db);
+
+        if (me) {
+          await linkRecords(recordId, me, 'created_by', db);
+        }
+
+        logger.info(`Created record ${recordId} for ${image.fileName}`);
       }
 
-      mediaId = newMedia.id;
-      await db.update(lightroomImages).set({ mediaId }).where(eq(lightroomImages.id, image.id));
-
-      logger.info(`Created media ${mediaId} for ${image.fileName}`);
-    }
-
-    // Create record if needed
-    if (!image.record) {
-      logger.info(`Creating record for ${image.fileName}`);
-      const newRecordDefaults = mapLightroomImageToRecord(image);
-
-      const [newRecord] = await db
-        .insert(records)
-        .values(newRecordDefaults)
-        .onConflictDoUpdate({
-          target: records.id,
-          set: {
-            recordUpdatedAt: new Date(),
-          },
-        })
-        .returning({ id: records.id });
-
-      if (!newRecord) {
-        throw new Error('Failed to create record');
+      // Link media to record if both exist
+      if (mediaId && recordId) {
+        logger.info(`Linking media ${mediaId} to record ${recordId}`);
+        await db
+          .update(media)
+          .set({
+            recordId,
+          })
+          .where(eq(media.id, mediaId));
       }
 
-      recordId = newRecord.id;
-      await db.update(lightroomImages).set({ recordId }).where(eq(lightroomImages.id, image.id));
+      processed++;
+    },
+  });
+  throwPoolFailures(imageResults, 'Lightroom image processing', unmappedImages.length);
 
-      // Link to author if found
-      const me = await getRecordId('nick-trombley', db);
-
-      if (me) {
-        await linkRecords(recordId, me, 'created_by', db);
-      }
-
-      logger.info(`Created record ${recordId} for ${image.fileName}`);
-    }
-
-    // Link media to record if both exist
-    if (mediaId && recordId) {
-      logger.info(`Linking media ${mediaId} to record ${recordId}`);
-      await db
-        .update(media)
-        .set({
-          recordId,
-        })
-        .where(eq(media.id, mediaId));
-    }
-  }
-
-  logger.complete(`Processed ${unmappedImages.length} Lightroom images`);
+  logger.complete(`Processed ${processed} of ${unmappedImages.length} Lightroom images`);
 };
 
 export const createRecordMediaLinks = async () => {
@@ -262,15 +279,18 @@ export const createRecordMediaLinks = async () => {
 
   logger.info(`Found ${images.length} Lightroom images with both record and media IDs`);
 
-  for (const image of images) {
-    logger.info(`Linking media ${image.mediaId} to record ${image.recordId}`);
-    await db
-      .update(media)
-      .set({
-        recordId: image.recordId!,
-      })
-      .where(eq(media.id, image.mediaId!));
-  }
+  const linkResults = await runConcurrentPool({
+    items: images,
+    concurrency: DB_CONCURRENCY,
+    async worker(image) {
+      const { recordId, mediaId } = image;
+      if (!recordId || !mediaId) return;
+
+      logger.info(`Linking media ${mediaId} to record ${recordId}`);
+      await db.update(media).set({ recordId }).where(eq(media.id, mediaId));
+    },
+  });
+  throwPoolFailures(linkResults, 'Lightroom record-media linking', images.length);
 
   logger.complete(`Linked ${images.length} media items to records`);
 };

--- a/src/server/integrations/agents/helpers.ts
+++ b/src/server/integrations/agents/helpers.ts
@@ -106,12 +106,8 @@ export async function getRecentSessionFiles(
   basePath: string = CLAUDE_PROJECTS_PATH
 ): Promise<SessionFileInfo[]> {
   const projectDirs = await discoverProjectDirectories(basePath);
-  const allFiles: SessionFileInfo[] = [];
-
-  for (const projectDir of projectDirs) {
-    const files = await discoverSessionFiles(projectDir);
-    allFiles.push(...files);
-  }
+  const filesByProject = await Promise.all(projectDirs.map((dir) => discoverSessionFiles(dir)));
+  const allFiles = filesByProject.flat();
 
   // Sort by modification time, most recent first
   allFiles.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());

--- a/src/server/integrations/airtable/helpers.ts
+++ b/src/server/integrations/airtable/helpers.ts
@@ -30,56 +30,91 @@ type AttachmentWithExtract = AirtableAttachmentSelect & {
   extract: AirtableExtractSelect;
 };
 
-async function processAttachment(attachment: AttachmentWithExtract) {
+type ExtractImageField = ReturnType<typeof AirtableAttachmentSchema.parse>;
+type ExtractImageCache = Map<string, Promise<ExtractImageField[]>>;
+
+/**
+ * Fetches the current `images` field for an extract from the Airtable API,
+ * memoized per unique extract id so extracts with several attachments only
+ * incur a single API call. A fresh fetch is required because the images are
+ * signed Airtable URLs that expire, so the locally stored attachment row
+ * can't be reused in place of it.
+ */
+function fetchExtractImages(
+  extractId: string,
+  cache: ExtractImageCache
+): Promise<ExtractImageField[]> {
+  let promise = cache.get(extractId);
+  if (!promise) {
+    promise = airtableBase('extracts')
+      .find(extractId)
+      .then((currentRecord) => AirtableAttachmentSchema.array().parse(currentRecord.get('images')));
+    cache.set(extractId, promise);
+  }
+  return promise;
+}
+
+async function processAttachment(
+  attachment: AttachmentWithExtract,
+  extractImageCache: ExtractImageCache
+) {
   try {
     const { id: extractId, title: extractTitle } = attachment.extract;
-    const currentRecord = await airtableBase('extracts').find(extractId);
-    const attachments = AirtableAttachmentSchema.array().parse(currentRecord.get('images'));
+    const extractImages = await fetchExtractImages(extractId, extractImageCache);
+    const image = extractImages.find((candidate) => candidate.id === attachment.id);
 
-    for (const attachment of attachments) {
-      const { id, url: airtableUrl, filename } = attachment;
-      logger.info(`Processing ${filename} (${id})`);
+    if (!image) {
+      logger.error('Attachment not found in extract images', undefined, {
+        extractTitle,
+        extractId,
+        attachmentId: attachment.id,
+      });
+      return false;
+    }
 
-      try {
-        const r2Url = await uploadMediaToR2(airtableUrl);
-        if (!r2Url) {
-          logger.error('Failed to upload attachment to R2', undefined, {
-            extractTitle,
-            extractId,
-            filename,
-            attachmentId: id,
-          });
-          continue;
-        }
+    const { id, url: airtableUrl, filename } = image;
+    logger.info(`Processing ${filename} (${id})`);
 
-        logger.info(`Uploaded to R2: ${r2Url}`);
-
-        const [updatedAttachment] = await db
-          .update(airtableAttachments)
-          .set({
-            url: r2Url,
-            recordUpdatedAt: new Date(),
-          })
-          .where(eq(airtableAttachments.id, attachment.id))
-          .returning();
-
-        if (!updatedAttachment) {
-          logger.error('Failed to update attachment in database', undefined, {
-            extractTitle,
-            extractId,
-            filename,
-            attachmentId: id,
-            r2Url,
-          });
-        }
-      } catch (error) {
-        logger.error('Error processing attachment', error, {
+    try {
+      const r2Url = await uploadMediaToR2(airtableUrl);
+      if (!r2Url) {
+        logger.error('Failed to upload attachment to R2', undefined, {
           extractTitle,
           extractId,
           filename,
           attachmentId: id,
         });
+        return false;
       }
+
+      logger.info(`Uploaded to R2: ${r2Url}`);
+
+      const [updatedAttachment] = await db
+        .update(airtableAttachments)
+        .set({
+          url: r2Url,
+          recordUpdatedAt: new Date(),
+        })
+        .where(eq(airtableAttachments.id, attachment.id))
+        .returning();
+
+      if (!updatedAttachment) {
+        logger.error('Failed to update attachment in database', undefined, {
+          extractTitle,
+          extractId,
+          filename,
+          attachmentId: id,
+          r2Url,
+        });
+      }
+    } catch (error) {
+      logger.error('Error processing attachment', error, {
+        extractTitle,
+        extractId,
+        filename,
+        attachmentId: id,
+      });
+      return false;
     }
 
     return true;
@@ -110,10 +145,12 @@ export async function storeMedia() {
 
   logger.info(`Found ${attachments.length} attachments to process`);
 
+  const extractImageCache: ExtractImageCache = new Map();
+
   const results = await runConcurrentPool({
     items: attachments,
     concurrency: 50,
-    worker: processAttachment,
+    worker: (attachment) => processAttachment(attachment, extractImageCache),
     onProgress: (completed, total) => {
       if (completed % 10 === 0 || completed === total) {
         logger.info(`Progress: ${completed}/${total} attachments processed`);

--- a/src/server/integrations/airtable/map.ts
+++ b/src/server/integrations/airtable/map.ts
@@ -19,8 +19,12 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { getMediaInsertData } from '@/server/lib/media';
 import { mapUrl } from '@/server/lib/url-utils';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { bulkInsertLinks } from '../common/db-helpers';
 import { createIntegrationLogger } from '../common/logging';
+
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 
 const logger = createIntegrationLogger('airtable', 'map');
 
@@ -78,33 +82,39 @@ export async function createRecordsFromAirtableFormats() {
 
   logger.info(`Found ${formats.length} unmapped Airtable formats`);
 
-  for (const format of formats) {
-    const record = mapFormatToRecord(format);
-    logger.info(`Creating record for format ${format.name}`);
+  let processed = 0;
+  const formatResults = await runConcurrentPool({
+    items: formats,
+    concurrency: DB_CONCURRENCY,
+    async worker(format) {
+      const record = mapFormatToRecord(format);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(record)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(record)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: { recordUpdatedAt: new Date() },
+        })
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      logger.error(`Failed to create record for format ${format.name}`);
-      continue;
-    }
+      if (!newRecord) {
+        logger.error(`Failed to create record for format ${format.name}`);
+        return;
+      }
 
-    await db
-      .update(airtableFormats)
-      .set({ recordId: newRecord.id })
-      .where(eq(airtableFormats.id, format.id));
+      await db
+        .update(airtableFormats)
+        .set({ recordId: newRecord.id })
+        .where(eq(airtableFormats.id, format.id));
 
-    logger.info(`Linked format ${format.name} to record ${newRecord.id}`);
-  }
+      logger.info(`Linked format ${format.name} to record ${newRecord.id}`);
+      processed++;
+    },
+  });
+  throwPoolFailures(formatResults, 'Airtable format→record mapping', formats.length);
 
-  logger.complete(`Processed ${formats.length} Airtable formats`);
+  logger.complete(`Processed ${processed} of ${formats.length} Airtable formats`);
 }
 
 // ------------------------------------------------------------------------
@@ -156,32 +166,39 @@ export async function createRecordsFromAirtableCreators() {
 
   logger.info(`Found ${creators.length} unmapped Airtable creators`);
 
-  for (const creator of creators) {
-    const entity = mapAirtableCreatorToRecord(creator);
+  let processed = 0;
+  const creatorResults = await runConcurrentPool({
+    items: creators,
+    concurrency: DB_CONCURRENCY,
+    async worker(creator) {
+      const entity = mapAirtableCreatorToRecord(creator);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(entity)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(entity)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: { recordUpdatedAt: new Date() },
+        })
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      logger.error(`Failed to create record for creator ${creator.name}`);
-      continue;
-    }
+      if (!newRecord) {
+        logger.error(`Failed to create record for creator ${creator.name}`);
+        return;
+      }
 
-    await db
-      .update(airtableCreators)
-      .set({ recordId: newRecord.id })
-      .where(eq(airtableCreators.id, creator.id));
+      await db
+        .update(airtableCreators)
+        .set({ recordId: newRecord.id })
+        .where(eq(airtableCreators.id, creator.id));
 
-    logger.info(`Linked creator ${creator.name} to record ${newRecord.id}`);
-  }
+      logger.info(`Linked creator ${creator.name} to record ${newRecord.id}`);
+      processed++;
+    },
+  });
+  throwPoolFailures(creatorResults, 'Airtable creator→record mapping', creators.length);
 
-  logger.complete(`Processed ${creators.length} Airtable creators`);
+  logger.complete(`Processed ${processed} of ${creators.length} Airtable creators`);
 }
 
 // ------------------------------------------------------------------------
@@ -233,32 +250,39 @@ export async function createRecordsFromAirtableSpaces() {
 
   logger.info(`Found ${spaces.length} unmapped Airtable spaces`);
 
-  for (const space of spaces) {
-    const record = mapAirtableSpaceToRecord(space);
+  let processed = 0;
+  const spaceResults = await runConcurrentPool({
+    items: spaces,
+    concurrency: DB_CONCURRENCY,
+    async worker(space) {
+      const record = mapAirtableSpaceToRecord(space);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(record)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(record)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: { recordUpdatedAt: new Date() },
+        })
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      logger.error(`Failed to create record for space ${space.name}`);
-      continue;
-    }
+      if (!newRecord) {
+        logger.error(`Failed to create record for space ${space.name}`);
+        return;
+      }
 
-    await db
-      .update(airtableSpaces)
-      .set({ recordId: newRecord.id })
-      .where(eq(airtableSpaces.id, space.id));
+      await db
+        .update(airtableSpaces)
+        .set({ recordId: newRecord.id })
+        .where(eq(airtableSpaces.id, space.id));
 
-    logger.info(`Linked space ${space.name} to record ${newRecord.id}`);
-  }
+      logger.info(`Linked space ${space.name} to record ${newRecord.id}`);
+      processed++;
+    },
+  });
+  throwPoolFailures(spaceResults, 'Airtable space→record mapping', spaces.length);
 
-  logger.complete(`Processed ${spaces.length} Airtable spaces`);
+  logger.complete(`Processed ${processed} of ${spaces.length} Airtable spaces`);
 }
 
 // ------------------------------------------------------------------------
@@ -423,43 +447,48 @@ export async function createRecordsFromAirtableExtracts() {
   // Pass 1: Create records and link media
   // ------------------------------------------------------------------------
   logger.info('Starting Pass 1: Create records and link media');
-  for (const extract of extracts) {
-    const recordPayload = mapAirtableExtractToRecord(extract);
+  const pass1Results = await runConcurrentPool({
+    items: extracts,
+    concurrency: DB_CONCURRENCY,
+    async worker(extract) {
+      const recordPayload = mapAirtableExtractToRecord(extract);
 
-    const [insertedRecord] = await db
-      .insert(records)
-      .values(recordPayload)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: {
-          recordUpdatedAt: new Date(),
-        },
-      })
-      .returning({ id: records.id });
+      const [insertedRecord] = await db
+        .insert(records)
+        .values(recordPayload)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: {
+            recordUpdatedAt: new Date(),
+          },
+        })
+        .returning({ id: records.id });
 
-    if (!insertedRecord) {
-      logger.error(`Failed to create record for Airtable extract ${extract.id}`);
-      continue;
-    }
-
-    await db
-      .update(airtableExtracts)
-      .set({ recordId: insertedRecord.id })
-      .where(eq(airtableExtracts.id, extract.id));
-
-    recordMap.set(extract.id, insertedRecord.id);
-    logger.info(`Created record ${insertedRecord.id} for Airtable extract ${extract.id}`);
-
-    for (const attachment of extract.attachments) {
-      if (attachment.mediaId) {
-        await db
-          .update(media)
-          .set({ recordId: insertedRecord.id })
-          .where(eq(media.id, attachment.mediaId));
-        logger.info(`Linked media ${attachment.mediaId} to record ${insertedRecord.id}`);
+      if (!insertedRecord) {
+        logger.error(`Failed to create record for Airtable extract ${extract.id}`);
+        return;
       }
-    }
-  }
+
+      await db
+        .update(airtableExtracts)
+        .set({ recordId: insertedRecord.id })
+        .where(eq(airtableExtracts.id, extract.id));
+
+      recordMap.set(extract.id, insertedRecord.id);
+      logger.info(`Created record ${insertedRecord.id} for Airtable extract ${extract.id}`);
+
+      for (const attachment of extract.attachments) {
+        if (attachment.mediaId) {
+          await db
+            .update(media)
+            .set({ recordId: insertedRecord.id })
+            .where(eq(media.id, attachment.mediaId));
+          logger.info(`Linked media ${attachment.mediaId} to record ${insertedRecord.id}`);
+        }
+      }
+    },
+  });
+  throwPoolFailures(pass1Results, 'Airtable extract→record mapping', extracts.length);
   logger.info('Completed Pass 1.');
 
   // ------------------------------------------------------------------------

--- a/src/server/integrations/airtable/sync.ts
+++ b/src/server/integrations/airtable/sync.ts
@@ -19,6 +19,8 @@ import {
 import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { uploadMediaToR2 } from '@/server/lib/media';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
+import { conflictUpdateSet } from '../common/db-helpers';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -34,6 +36,9 @@ import {
 import { CreatorFieldSetSchema, ExtractFieldSetSchema, SpaceFieldSetSchema } from './types';
 
 const logger = createIntegrationLogger('airtable', 'sync');
+
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 
 /**
  * Synchronizes Airtable creators with the database
@@ -107,18 +112,24 @@ async function syncCreators(integrationRunId: number, collectDebugData?: unknown
 
     // Use a transaction to ensure all creators are synced atomically
     await db.transaction(async (tx) => {
-      for (const creator of creatorsToSync) {
-        logger.info(`Syncing creator ${creator.name}`);
-        await tx
-          .insert(airtableCreators)
-          .values(creator)
-          .onConflictDoUpdate({
-            target: [airtableCreators.id],
-            set: {
-              ...creator,
-            },
-          });
-      }
+      await tx
+        .insert(airtableCreators)
+        .values(creatorsToSync)
+        .onConflictDoUpdate({
+          target: [airtableCreators.id],
+          set: conflictUpdateSet(airtableCreators, [
+            'name',
+            'type',
+            'primaryProject',
+            'website',
+            'professions',
+            'organizations',
+            'nationalities',
+            'contentCreatedAt',
+            'contentUpdatedAt',
+            'integrationRunId',
+          ]),
+        });
     });
 
     logger.complete(`Synced creators`, creatorsToSync.length);
@@ -194,18 +205,20 @@ async function syncSpaces(integrationRunId: number, collectDebugData?: unknown[]
 
     // Use a transaction to ensure all spaces are synced atomically
     await db.transaction(async (tx) => {
-      for (const space of spacesToSync) {
-        logger.info(`Syncing space ${space.name}`);
-        await tx
-          .insert(airtableSpaces)
-          .values(space)
-          .onConflictDoUpdate({
-            target: [airtableSpaces.id],
-            set: {
-              ...space,
-            },
-          });
-      }
+      await tx
+        .insert(airtableSpaces)
+        .values(spacesToSync)
+        .onConflictDoUpdate({
+          target: [airtableSpaces.id],
+          set: conflictUpdateSet(airtableSpaces, [
+            'name',
+            'fullName',
+            'icon',
+            'contentCreatedAt',
+            'contentUpdatedAt',
+            'integrationRunId',
+          ]),
+        });
     });
 
     logger.complete(`Synced spaces`, spacesToSync.length);
@@ -277,7 +290,33 @@ async function syncExtracts(
 
     logger.info(`Syncing ${parsedRecords.length} extracts`);
 
-    // Step 4: First pass - Upsert extracts and their relationships
+    // Step 4: Upload every attachment image across all extracts up front, so the
+    // per-extract transaction below only performs (fast) database writes. A
+    // failed upload aborts the sync, matching the previous behavior where an
+    // upload failure inside the shared transaction rolled back every extract.
+    const imagesToUpload = parsedRecords.flatMap((record) =>
+      (record.fields.images ?? []).map((image) => ({ extractId: record.id, image }))
+    );
+
+    const uploadResults = await runConcurrentPool({
+      items: imagesToUpload,
+      concurrency: DB_CONCURRENCY,
+      async worker({ extractId, image }) {
+        logger.info(`Uploading media ${image.filename} for extract ${extractId}`);
+        const permanentUrl = await uploadMediaToR2(image.url);
+        return { imageId: image.id, permanentUrl };
+      },
+    });
+    throwPoolFailures(uploadResults, 'Airtable extract image upload', imagesToUpload.length);
+
+    const uploadedUrlsByImageId = new Map<string, string>();
+    for (const result of uploadResults) {
+      if (result.ok) {
+        uploadedUrlsByImageId.set(result.value.imageId, result.value.permanentUrl);
+      }
+    }
+
+    // Step 5: First pass - Upsert extracts and their relationships
     await db.transaction(async (tx) => {
       for (const record of parsedRecords) {
         const fields = record.fields;
@@ -316,11 +355,11 @@ async function syncExtracts(
         // Process attachments
         if (fields.images) {
           for (const image of fields.images) {
-            logger.info(`Uploading media ${image.filename} for extract ${record.id}`);
-
-            // Upload the image to R2 storage
-            const permanentUrl = await uploadMediaToR2(image.url);
-            logger.info(`Uploaded to ${permanentUrl}, inserting attachment...`);
+            const permanentUrl = uploadedUrlsByImageId.get(image.id);
+            if (!permanentUrl) {
+              throw new Error(`Missing uploaded URL for attachment ${image.id}`);
+            }
+            logger.info(`Inserting attachment ${image.filename} for extract ${record.id}`);
 
             // Create the attachment record
             const attachment: AirtableAttachmentInsert = {
@@ -371,7 +410,7 @@ async function syncExtracts(
       }
     });
 
-    // Step 5: Second pass - Update parent-child relationships and connections
+    // Step 6: Second pass - Update parent-child relationships and connections
     await updateExtractRelationships(parsedRecords);
 
     collectDebugData?.push(...updatedRecords);
@@ -395,27 +434,43 @@ async function syncExtracts(
 async function updateExtractRelationships(
   parsedRecords: Array<{ id: string; fields: ReturnType<typeof ExtractFieldSetSchema.parse> }>
 ): Promise<void> {
+  const parentUpdates: Array<{ id: string; parentId: string }> = [];
+  const connectionValues: AirtableExtractConnectionInsert[] = [];
+
   for (const record of parsedRecords) {
     const { parentId, connectionIds } = record.fields;
 
-    // Update parent-child relationship
-    if (parentId?.[0]) {
-      await db
-        .update(airtableExtracts)
-        .set({ parentId: parentId[0] })
-        .where(eq(airtableExtracts.id, record.id));
+    const firstParentId = parentId?.[0];
+    if (firstParentId) {
+      parentUpdates.push({ id: record.id, parentId: firstParentId });
     }
 
-    // Update connections
     if (connectionIds) {
       for (const connectionId of connectionIds) {
-        const link: AirtableExtractConnectionInsert = {
-          fromExtractId: record.id,
-          toExtractId: connectionId,
-        };
-        await db.insert(airtableExtractConnections).values(link).onConflictDoNothing();
+        connectionValues.push({ fromExtractId: record.id, toExtractId: connectionId });
       }
     }
+  }
+
+  // Update connections in a single bulk insert
+  if (connectionValues.length > 0) {
+    await db.insert(airtableExtractConnections).values(connectionValues).onConflictDoNothing();
+  }
+
+  // Update parent-child relationships (each row targets a different parentId, so
+  // these remain individual updates, pooled for concurrency)
+  if (parentUpdates.length > 0) {
+    const parentUpdateResults = await runConcurrentPool({
+      items: parentUpdates,
+      concurrency: DB_CONCURRENCY,
+      async worker(update) {
+        await db
+          .update(airtableExtracts)
+          .set({ parentId: update.parentId })
+          .where(eq(airtableExtracts.id, update.id));
+      },
+    });
+    throwPoolFailures(parentUpdateResults, 'Airtable extract parent update', parentUpdates.length);
   }
 }
 
@@ -455,6 +510,24 @@ async function syncFormats(integrationRunId: number, collectDebugData?: unknown[
 
     logger.info(`Syncing ${unlinkedExtracts.length} formats`);
 
+    // Look up all formats that might already exist for these extracts once,
+    // instead of a findFirst query per extract inside the loop below.
+    const formatStrings = [
+      ...new Set(
+        unlinkedExtracts
+          .map((extract) => extract.formatString)
+          .filter((formatString): formatString is string => formatString !== null)
+      ),
+    ];
+    const existingFormats = await db.query.airtableFormats.findMany({
+      where: {
+        name: {
+          in: formatStrings,
+        },
+      },
+    });
+    const formatMap = new Map(existingFormats.map((format) => [format.name, format]));
+
     // Process each unlinked extract
     await db.transaction(async (tx) => {
       for (const extract of unlinkedExtracts) {
@@ -465,11 +538,7 @@ async function syncFormats(integrationRunId: number, collectDebugData?: unknown[
         }
 
         // Try to find an existing format
-        const format = await tx.query.airtableFormats.findFirst({
-          where: {
-            name: extract.formatString,
-          },
-        });
+        const format = formatMap.get(extract.formatString);
 
         if (format) {
           // Link to existing format
@@ -501,6 +570,8 @@ async function syncFormats(integrationRunId: number, collectDebugData?: unknown[
             logger.error(`Failed to create new format ${extract.formatString}`);
             continue;
           }
+
+          formatMap.set(newFormat.name, newFormat);
 
           // Link to the new format
           await tx

--- a/src/server/integrations/airtable/sync.ts
+++ b/src/server/integrations/airtable/sync.ts
@@ -20,7 +20,6 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { uploadMediaToR2 } from '@/server/lib/media';
 import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
-import { conflictUpdateSet } from '../common/db-helpers';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -112,24 +111,18 @@ async function syncCreators(integrationRunId: number, collectDebugData?: unknown
 
     // Use a transaction to ensure all creators are synced atomically
     await db.transaction(async (tx) => {
-      await tx
-        .insert(airtableCreators)
-        .values(creatorsToSync)
-        .onConflictDoUpdate({
-          target: [airtableCreators.id],
-          set: conflictUpdateSet(airtableCreators, [
-            'name',
-            'type',
-            'primaryProject',
-            'website',
-            'professions',
-            'organizations',
-            'nationalities',
-            'contentCreatedAt',
-            'contentUpdatedAt',
-            'integrationRunId',
-          ]),
-        });
+      for (const creator of creatorsToSync) {
+        logger.info(`Syncing creator ${creator.name}`);
+        await tx
+          .insert(airtableCreators)
+          .values(creator)
+          .onConflictDoUpdate({
+            target: [airtableCreators.id],
+            set: {
+              ...creator,
+            },
+          });
+      }
     });
 
     logger.complete(`Synced creators`, creatorsToSync.length);
@@ -205,20 +198,18 @@ async function syncSpaces(integrationRunId: number, collectDebugData?: unknown[]
 
     // Use a transaction to ensure all spaces are synced atomically
     await db.transaction(async (tx) => {
-      await tx
-        .insert(airtableSpaces)
-        .values(spacesToSync)
-        .onConflictDoUpdate({
-          target: [airtableSpaces.id],
-          set: conflictUpdateSet(airtableSpaces, [
-            'name',
-            'fullName',
-            'icon',
-            'contentCreatedAt',
-            'contentUpdatedAt',
-            'integrationRunId',
-          ]),
-        });
+      for (const space of spacesToSync) {
+        logger.info(`Syncing space ${space.name}`);
+        await tx
+          .insert(airtableSpaces)
+          .values(space)
+          .onConflictDoUpdate({
+            target: [airtableSpaces.id],
+            set: {
+              ...space,
+            },
+          });
+      }
     });
 
     logger.complete(`Synced spaces`, spacesToSync.length);

--- a/src/server/integrations/browser-history/sync-all.ts
+++ b/src/server/integrations/browser-history/sync-all.ts
@@ -1,3 +1,4 @@
+import { withBufferedLogs } from '../common/buffered-logs';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -17,39 +18,53 @@ async function syncAllBrowserData(
   collectDebugData?: { arc: unknown[]; dia: unknown[] }
 ): Promise<number> {
   logger.start('Starting all browser history synchronization');
-  let totalEntriesCreated = 0;
 
-  // Run Arc browser sync
-  try {
-    logger.info('Starting Arc Browser Sync');
-    const arcEntries = await syncSingleBrowser(arcConfig, integrationRunId, collectDebugData?.arc);
-    totalEntriesCreated += arcEntries;
-    logger.complete('Arc Browser Sync', arcEntries);
-  } catch (error) {
-    if (error instanceof BrowserNotInstalledError) {
-      logger.warn(error.message + ' Skipping Arc sync.');
-    } else {
-      logger.error('Arc browser sync failed', error);
+  const syncArc = async (): Promise<number> => {
+    try {
+      logger.info('Starting Arc Browser Sync');
+      const arcEntries = await syncSingleBrowser(
+        arcConfig,
+        integrationRunId,
+        collectDebugData?.arc
+      );
+      logger.complete('Arc Browser Sync', arcEntries);
+      return arcEntries;
+    } catch (error) {
+      if (error instanceof BrowserNotInstalledError) {
+        logger.warn(error.message + ' Skipping Arc sync.');
+      } else {
+        logger.error('Arc browser sync failed', error);
+      }
+      // Continue with Dia sync even if Arc fails
+      return 0;
     }
-    // Continue with Dia sync even if Arc fails
-  }
+  };
 
-  // Add a small delay between syncs to ensure clean separation
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // Run Dia browser sync
-  try {
-    logger.info('Starting Dia Browser Sync');
-    const diaEntries = await syncSingleBrowser(diaConfig, integrationRunId, collectDebugData?.dia);
-    totalEntriesCreated += diaEntries;
-    logger.complete('Dia Browser Sync', diaEntries);
-  } catch (error) {
-    if (error instanceof BrowserNotInstalledError) {
-      logger.warn(error.message + ' Skipping Dia sync.');
-    } else {
-      logger.error('Dia browser sync failed', error);
+  const syncDia = async (): Promise<number> => {
+    try {
+      logger.info('Starting Dia Browser Sync');
+      const diaEntries = await syncSingleBrowser(
+        diaConfig,
+        integrationRunId,
+        collectDebugData?.dia
+      );
+      logger.complete('Dia Browser Sync', diaEntries);
+      return diaEntries;
+    } catch (error) {
+      if (error instanceof BrowserNotInstalledError) {
+        logger.warn(error.message + ' Skipping Dia sync.');
+      } else {
+        logger.error('Dia browser sync failed', error);
+      }
+      return 0;
     }
-  }
+  };
+
+  const [arcEntries, diaEntries] = await Promise.all([
+    withBufferedLogs(syncArc),
+    withBufferedLogs(syncDia),
+  ]);
+  const totalEntriesCreated = arcEntries + diaEntries;
 
   logger.complete('All browser history synchronization completed', totalEntriesCreated);
   return totalEntriesCreated;

--- a/src/server/integrations/browser-history/sync.ts
+++ b/src/server/integrations/browser-history/sync.ts
@@ -2,6 +2,7 @@ import { arcSchema, browsingHistory, type Browser, type BrowsingHistoryInsert } 
 import { and, eq, gt, isNotNull, ne, notLike, sql } from 'drizzle-orm';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
 import {
@@ -251,20 +252,20 @@ async function syncBrowserHistory(
  * @returns Promise that resolves to true if the sync should proceed, false otherwise
  */
 async function checkHostname(currentHostname: string, _browser: Browser): Promise<boolean> {
-  // Get all unique hostnames from the database
-  const uniqueHostnames = await db
-    .select({
-      hostname: browsingHistory.hostname,
-    })
-    .from(browsingHistory)
-    // .where(eq(browsingHistory.browser, browser))
-    .groupBy(browsingHistory.hostname);
-
-  const knownHostnames = new Set(uniqueHostnames.map((h) => h.hostname));
+  const existing = await db.query.browsingHistory.findFirst({
+    where: { hostname: currentHostname },
+    columns: { hostname: true },
+  });
 
   // If current hostname is not in the database, ask for confirmation
-  if (!knownHostnames.has(currentHostname)) {
-    logger.info('Known hostnames: ' + Array.from(knownHostnames).join(', '));
+  if (!existing) {
+    const uniqueHostnames = await db
+      .select({
+        hostname: browsingHistory.hostname,
+      })
+      .from(browsingHistory)
+      .groupBy(browsingHistory.hostname);
+    logger.info('Known hostnames: ' + uniqueHostnames.map((h) => h.hostname).join(', '));
     return askForConfirmation(
       `Current hostname "${currentHostname}" has not been seen before. Proceed with sync?`
     );
@@ -505,30 +506,37 @@ async function insertHistoryEntries(processedHistory: BrowsingHistoryInsert[]): 
   }
 
   // Insert in batches to avoid overwhelming the database
-  const totalBatches = Math.ceil(dedupedHistory.length / BATCH_SIZE);
-  let skippedCount = 0;
-
+  const batches: BrowsingHistoryInsert[][] = [];
   for (let i = 0; i < dedupedHistory.length; i += BATCH_SIZE) {
-    const batch = dedupedHistory.slice(i, i + BATCH_SIZE);
-
-    // Use onConflictDoNothing to skip duplicate entries
-    // The unique constraint on (hostname, viewEpochMicroseconds, url) will prevent duplicates
-    const result = await db
-      .insert(browsingHistory)
-      .values(batch)
-      .onConflictDoNothing()
-      .returning({ id: browsingHistory.id });
-
-    const insertedCount = result.length;
-    const expectedCount = batch.length;
-    if (insertedCount < expectedCount) {
-      skippedCount += expectedCount - insertedCount;
-    }
-
-    logger.info(
-      `Inserted batch ${Math.floor(i / BATCH_SIZE) + 1} of ${totalBatches} (${insertedCount}/${expectedCount} entries)`
-    );
+    batches.push(dedupedHistory.slice(i, i + BATCH_SIZE));
   }
+
+  const results = await runConcurrentPool({
+    items: batches,
+    concurrency: 8,
+    worker: async (batch, index) => {
+      // Use onConflictDoNothing to skip duplicate entries
+      // The unique constraint on (hostname, viewEpochMicroseconds, url) will prevent duplicates
+      const result = await db
+        .insert(browsingHistory)
+        .values(batch)
+        .onConflictDoNothing()
+        .returning({ id: browsingHistory.id });
+
+      const insertedCount = result.length;
+      const expectedCount = batch.length;
+
+      logger.info(
+        `Inserted batch ${index + 1} of ${batches.length} (${insertedCount}/${expectedCount} entries)`
+      );
+
+      return expectedCount - insertedCount;
+    },
+  });
+
+  throwPoolFailures(results, 'Insert history batch', batches.length);
+
+  const skippedCount = results.reduce((sum, r) => sum + (r.ok ? r.value : 0), 0);
 
   if (skippedCount > 0) {
     logger.info(`Skipped ${skippedCount} duplicate entries`);

--- a/src/server/integrations/common/buffered-logs.ts
+++ b/src/server/integrations/common/buffered-logs.ts
@@ -1,0 +1,34 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const bufferStorage = new AsyncLocalStorage<unknown[][]>();
+
+/**
+ * Writes a log line to stderr, or to the active buffer when called inside a
+ * `withBufferedLogs` scope.
+ */
+export function writeLogLine(...args: unknown[]): void {
+  const buffer = bufferStorage.getStore();
+  if (buffer) {
+    buffer.push(args);
+    return;
+  }
+  console.error(...args);
+}
+
+/**
+ * Runs a task with its log output buffered, flushing the buffer as one
+ * contiguous block when the task settles (including on error). This lets
+ * independent tasks run concurrently without interleaving their streamed
+ * output. Scopes nest: an inner scope flushes into its parent's buffer, so
+ * the parent still emits a single block.
+ */
+export async function withBufferedLogs<T>(fn: () => Promise<T>): Promise<T> {
+  const buffer: unknown[][] = [];
+  try {
+    return await bufferStorage.run(buffer, fn);
+  } finally {
+    for (const args of buffer) {
+      writeLogLine(...args);
+    }
+  }
+}

--- a/src/server/integrations/common/db-helpers.ts
+++ b/src/server/integrations/common/db-helpers.ts
@@ -1,4 +1,6 @@
 import { links as linksTable, type LinkInsert, type PredicateSlug } from '@hozo';
+import { getColumns, sql, type SQL } from 'drizzle-orm';
+import type { PgTable } from 'drizzle-orm/pg-core';
 import { type Db } from '@/server/db/connections/postgres';
 import type { RecordSlug } from '@/server/db/seed';
 import { createIntegrationLogger } from './logging';
@@ -67,6 +69,27 @@ export async function linkRecords(
     logger.error(`Failed to link record ${sourceId} to record ${targetId}`, error);
     throw error;
   }
+}
+
+/**
+ * Builds an `onConflictDoUpdate` set that overwrites the given columns with
+ * the incoming (excluded) row values, enabling multi-row upserts via a single
+ * `.values(rows)` insert.
+ */
+export function conflictUpdateSet<TTable extends PgTable>(
+  table: TTable,
+  columns: Extract<keyof TTable['_']['columns'], string>[]
+): Partial<Record<Extract<keyof TTable['_']['columns'], string>, SQL>> {
+  const tableColumns = getColumns(table);
+  const set: Partial<Record<Extract<keyof TTable['_']['columns'], string>, SQL>> = {};
+  for (const column of columns) {
+    const tableColumn = tableColumns[column];
+    if (!tableColumn) {
+      throw new Error(`conflictUpdateSet: unknown column ${column}`);
+    }
+    set[column] = sql.raw(`excluded."${tableColumn.name}"`);
+  }
+  return set;
 }
 
 export async function bulkInsertLinks(links: LinkInsert[], db: Db): Promise<void> {

--- a/src/server/integrations/common/db-helpers.ts
+++ b/src/server/integrations/common/db-helpers.ts
@@ -1,6 +1,4 @@
 import { links as linksTable, type LinkInsert, type PredicateSlug } from '@hozo';
-import { getColumns, sql, type SQL } from 'drizzle-orm';
-import type { PgTable } from 'drizzle-orm/pg-core';
 import { type Db } from '@/server/db/connections/postgres';
 import type { RecordSlug } from '@/server/db/seed';
 import { createIntegrationLogger } from './logging';
@@ -69,27 +67,6 @@ export async function linkRecords(
     logger.error(`Failed to link record ${sourceId} to record ${targetId}`, error);
     throw error;
   }
-}
-
-/**
- * Builds an `onConflictDoUpdate` set that overwrites the given columns with
- * the incoming (excluded) row values, enabling multi-row upserts via a single
- * `.values(rows)` insert.
- */
-export function conflictUpdateSet<TTable extends PgTable>(
-  table: TTable,
-  columns: Extract<keyof TTable['_']['columns'], string>[]
-): Partial<Record<Extract<keyof TTable['_']['columns'], string>, SQL>> {
-  const tableColumns = getColumns(table);
-  const set: Partial<Record<Extract<keyof TTable['_']['columns'], string>, SQL>> = {};
-  for (const column of columns) {
-    const tableColumn = tableColumns[column];
-    if (!tableColumn) {
-      throw new Error(`conflictUpdateSet: unknown column ${column}`);
-    }
-    set[column] = sql.raw(`excluded."${tableColumn.name}"`);
-  }
-  return set;
 }
 
 export async function bulkInsertLinks(links: LinkInsert[], db: Db): Promise<void> {

--- a/src/server/integrations/common/logging.ts
+++ b/src/server/integrations/common/logging.ts
@@ -1,3 +1,5 @@
+import { writeLogLine } from './buffered-logs';
+
 /**
  * Creates a logger with a specific prefix for integration processes
  *
@@ -16,36 +18,36 @@ export function createIntegrationLogger(integration: string, process: string) {
   function log(level: Level, message: string, ...args: unknown[]) {
     const styledMessage = style(message, { ...styleForLevel(level), useAnsi });
     // Always log to stderr so CLI JSON output stays clean on stdout.
-    console.error(`${styledPrefix} ${styledMessage}`, ...args);
+    writeLogLine(`${styledPrefix} ${styledMessage}`, ...args);
   }
 
   function logError(message: string, error?: unknown, ...args: unknown[]) {
     const styledMessage = style(message, { ...styleForLevel('error'), useAnsi });
 
     if (error instanceof Error) {
-      console.error(`${styledPrefix} ${styledMessage}:`, error.message, ...args);
+      writeLogLine(`${styledPrefix} ${styledMessage}:`, error.message, ...args);
       if (error.cause) {
         if (error.cause instanceof Error) {
-          console.error(`${styledPrefix} ${styledMessage} cause:`, error.cause.message);
+          writeLogLine(`${styledPrefix} ${styledMessage} cause:`, error.cause.message);
           if (error.cause.stack) {
-            console.error(style(error.cause.stack, { dim: true, useAnsi }));
+            writeLogLine(style(error.cause.stack, { dim: true, useAnsi }));
           }
         } else {
-          console.error(`${styledPrefix} ${styledMessage} cause:`, error.cause);
+          writeLogLine(`${styledPrefix} ${styledMessage} cause:`, error.cause);
         }
       }
       if (error.stack) {
-        console.error(style(error.stack, { dim: true, useAnsi }));
+        writeLogLine(style(error.stack, { dim: true, useAnsi }));
       }
       return;
     }
 
     if (error !== undefined) {
-      console.error(`${styledPrefix} ${styledMessage}:`, error, ...args);
+      writeLogLine(`${styledPrefix} ${styledMessage}:`, error, ...args);
       return;
     }
 
-    console.error(`${styledPrefix} ${styledMessage}`, ...args);
+    writeLogLine(`${styledPrefix} ${styledMessage}`, ...args);
   }
 
   return {

--- a/src/server/integrations/feedbin/sync.ts
+++ b/src/server/integrations/feedbin/sync.ts
@@ -61,14 +61,28 @@ async function getRecentFeedIds(limit = 1000): Promise<Set<number>> {
   return new Set(rows.map((r) => r.id));
 }
 
+/** Chunk size for `in` queries against candidate entry IDs */
+const EXISTING_ENTRY_ID_CHUNK_SIZE = 1000;
+
 /**
- * Get ALL existing entry IDs from the database
+ * Get which of the given candidate entry IDs already exist in the database
  */
-async function getAllExistingEntryIds(): Promise<Set<number>> {
-  const rows = await db.query.feedEntries.findMany({
-    columns: { id: true },
-  });
-  return new Set(rows.map((r) => r.id));
+async function getExistingEntryIds(candidateIds: number[]): Promise<Set<number>> {
+  const existing = new Set<number>();
+
+  for (let i = 0; i < candidateIds.length; i += EXISTING_ENTRY_ID_CHUNK_SIZE) {
+    const chunk = candidateIds.slice(i, i + EXISTING_ENTRY_ID_CHUNK_SIZE);
+    if (chunk.length === 0) continue;
+
+    const rows = await db.query.feedEntries.findMany({
+      where: { id: { in: chunk } },
+      columns: { id: true },
+    });
+
+    for (const row of rows) existing.add(row.id);
+  }
+
+  return existing;
 }
 
 /**
@@ -108,11 +122,6 @@ async function bulkUpdateReadStatus(entryIds: number[], read: boolean): Promise<
     } catch (error) {
       logger.error(`Bulk update batch failed or timed out`, error);
       // Continue with next batch even if this one fails
-    }
-
-    // Add small delay between batches
-    if (i + BATCH_SIZE < entryIds.length) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
     }
   }
 }
@@ -175,6 +184,9 @@ async function syncSingleFeed(feedId: number, iconMap?: Map<string, string>): Pr
   }
 }
 
+/** Concurrency for upserting feeds */
+const FEED_CONCURRENCY = 10;
+
 /**
  * Sync feeds from Feedbin subscriptions
  */
@@ -186,78 +198,64 @@ async function syncFeeds(
   logger.start(`Syncing ${subscriptions.length} feeds`);
 
   const FEED_TIMEOUT_MS = 15000; // 15 seconds per feed
-  let successCount = 0;
-  let errorCount = 0;
 
-  for (const [index, subscription] of subscriptions.entries()) {
-    const feedStartTime = Date.now();
+  const results = await runConcurrentPool({
+    items: subscriptions,
+    concurrency: FEED_CONCURRENCY,
+    timeoutMs: FEED_TIMEOUT_MS,
+    worker: async (subscription, index) => {
+      // Extract domain from site URL for icon lookup
+      const siteUrl = subscription.site_url;
+      let iconUrl: string | null = null;
 
-    try {
-      // Set up timeout for individual feed processing
-      await Promise.race([
-        (async () => {
-          // Extract domain from site URL for icon lookup
-          const siteUrl = subscription.site_url;
-          let iconUrl: string | null = null;
+      if (siteUrl) {
+        try {
+          const url = new URL(siteUrl);
+          iconUrl = iconMap.get(url.hostname) || null;
+        } catch {
+          // Ignore URL parsing errors
+        }
+      }
 
-          if (siteUrl) {
-            try {
-              const url = new URL(siteUrl);
-              iconUrl = iconMap.get(url.hostname) || null;
-            } catch {
-              // Ignore URL parsing errors
-            }
-          }
+      // Upsert feed
+      await db
+        .insert(feeds)
+        .values({
+          id: subscription.feed_id,
+          name: subscription.title,
+          feedUrl: subscription.feed_url,
+          siteUrl: subscription.site_url,
+          iconUrl,
+          sources: ['feedbin'],
+          contentCreatedAt: subscription.created_at,
+        })
+        .onConflictDoUpdate({
+          target: feeds.id,
+          set: {
+            name: subscription.title,
+            feedUrl: subscription.feed_url,
+            siteUrl: subscription.site_url,
+            iconUrl,
+            recordUpdatedAt: new Date(),
+          },
+        });
 
-          // Upsert feed
-          await db
-            .insert(feeds)
-            .values({
-              id: subscription.feed_id,
-              name: subscription.title,
-              feedUrl: subscription.feed_url,
-              siteUrl: subscription.site_url,
-              iconUrl,
-              sources: ['feedbin'],
-              contentCreatedAt: subscription.created_at,
-            })
-            .onConflictDoUpdate({
-              target: feeds.id,
-              set: {
-                name: subscription.title,
-                feedUrl: subscription.feed_url,
-                siteUrl: subscription.site_url,
-                iconUrl,
-                recordUpdatedAt: new Date(),
-              },
-            });
-        })(),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error(`Feed sync timeout after ${FEED_TIMEOUT_MS}ms`)),
-            FEED_TIMEOUT_MS
-          )
-        ),
-      ]);
+      logger.info(`Synced feed "${subscription.title}" (${index + 1} of ${subscriptions.length})`);
+    },
+  });
 
-      successCount++;
-      const feedDuration = Date.now() - feedStartTime;
-      logger.info(
-        `Synced feed "${subscription.title}" (${index + 1} of ${subscriptions.length}) in ${feedDuration}ms`
-      );
-    } catch (error) {
-      errorCount++;
+  const successCount = results.filter((r) => r.ok).length;
+  const errorCount = results.length - successCount;
+
+  results.forEach((result, index) => {
+    if (!result.ok) {
+      const subscription = subscriptions[index];
       logger.warn(
-        `Failed to sync feed ${subscription.feed_id} (${index + 1} of ${subscriptions.length})`,
-        error
+        `Failed to sync feed ${subscription?.feed_id} (${index + 1} of ${subscriptions.length})`,
+        result.error
       );
     }
-
-    // Add small delay between feeds to prevent overwhelming the system
-    if (index < subscriptions.length - 1) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-  }
+  });
 
   logger.complete(`Synced ${successCount} feeds (${errorCount} errors)`);
 }
@@ -502,11 +500,6 @@ async function bulkUpdateStarredStatus(entryIds: number[], starred: boolean): Pr
       logger.error(`Bulk update batch failed or timed out`, error);
       // Continue with next batch even if this one fails
     }
-
-    // Add small delay between batches
-    if (i + BATCH_SIZE < entryIds.length) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
   }
 }
 
@@ -563,10 +556,9 @@ async function syncFeedbin(
     syncedFeedIds.clear();
 
     // Get existing IDs for recent entries and feeds
-    const [existingEntryStatuses, existingFeedIds, allExistingEntryIds] = await Promise.all([
+    const [existingEntryStatuses, existingFeedIds] = await Promise.all([
       getRecentEntryStatuses(),
       getRecentFeedIds(),
-      getAllExistingEntryIds(),
     ]);
 
     // Step 1: Get last sync time and fetch new subscriptions
@@ -628,11 +620,13 @@ async function syncFeedbin(
     // Combine all IDs we need to consider
     const idsToConsider = new Set<number>([...unreadSet, ...recentlyReadIds, ...starredSet]);
 
+    // Check which of the candidate IDs already exist in the database
+    const candidateIds = Array.from(new Set([...idsToConsider, ...updatedIds]));
+    const existingEntryIds = await getExistingEntryIds(candidateIds);
+
     // Split between new entries to fetch and updated entries to re-fetch
-    const newEntriesToFetch = Array.from(idsToConsider).filter(
-      (id) => !allExistingEntryIds.has(id)
-    );
-    const updatedEntriesToFetch = updatedIds.filter((id) => allExistingEntryIds.has(id));
+    const newEntriesToFetch = Array.from(idsToConsider).filter((id) => !existingEntryIds.has(id));
+    const updatedEntriesToFetch = updatedIds.filter((id) => existingEntryIds.has(id));
 
     logger.info(`Found ${newEntriesToFetch.length} new entries to fetch`);
     logger.info(`Found ${updatedEntriesToFetch.length} updated entries to re-fetch`);
@@ -673,29 +667,22 @@ async function syncFeedbin(
     if (missingFeedIds.length > 0) {
       logger.info(`Fetching ${missingFeedIds.length} missing feeds before syncing entries`);
 
-      const FEED_BATCH_SIZE = 20;
-      let feedFetchCount = 0;
-
-      for (let i = 0; i < missingFeedIds.length; i += FEED_BATCH_SIZE) {
-        const batch = missingFeedIds.slice(i, i + FEED_BATCH_SIZE);
-        logger.info(
-          `Processing feed batch ${Math.floor(i / FEED_BATCH_SIZE) + 1} of ${Math.ceil(missingFeedIds.length / FEED_BATCH_SIZE)}`
-        );
-
-        await Promise.all(
-          batch.map(async (feedId) => {
-            try {
-              feedFetchCount++;
-              await syncSingleFeed(feedId, iconMap);
-              syncedFeedIds.add(feedId);
-              existingFeedIds.add(feedId);
-              logger.info(`Fetched feed ${feedId} (${feedFetchCount} of ${missingFeedIds.length})`);
-            } catch (error) {
-              logger.warn(`Failed to fetch feed ${feedId}`, error);
-            }
-          })
-        );
-      }
+      await runConcurrentPool({
+        items: missingFeedIds,
+        concurrency: 20,
+        worker: async (feedId) => {
+          try {
+            await syncSingleFeed(feedId, iconMap);
+            syncedFeedIds.add(feedId);
+            existingFeedIds.add(feedId);
+          } catch (error) {
+            logger.warn(`Failed to fetch feed ${feedId}`, error);
+          }
+        },
+        onProgress: (completed, total) => {
+          logger.info(`Fetched feed ${completed} of ${total}`);
+        },
+      });
     }
 
     // Step 7: Sync entries

--- a/src/server/integrations/github/map.ts
+++ b/src/server/integrations/github/map.ts
@@ -9,10 +9,13 @@ import {
 import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { mapUrl } from '@/server/lib/url-utils';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { linkRecords } from '../common/db-helpers';
 import { createIntegrationLogger } from '../common/logging';
 
 const logger = createIntegrationLogger('github', 'map');
+
+const DB_CONCURRENCY = 10;
 
 /**
  * Maps a GitHub user to a record
@@ -72,34 +75,38 @@ export async function createRecordsFromGithubUsers() {
 
   logger.info(`Found ${unmappedUsers.length} unmapped GitHub users`);
 
-  for (const user of unmappedUsers) {
-    const newEntityDefaults = mapGithubUserToRecord(user);
+  const results = await runConcurrentPool({
+    items: unmappedUsers,
+    concurrency: DB_CONCURRENCY,
+    worker: async (user) => {
+      const newEntityDefaults = mapGithubUserToRecord(user);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(newEntityDefaults)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(newEntityDefaults)
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
-
-    logger.info(`Created record ${newRecord.id} for ${user.login} (${user.id})`);
-
-    await db.update(githubUsers).set({ recordId: newRecord.id }).where(eq(githubUsers.id, user.id));
-
-    // Link repositories to creator
-    for (const repository of user.repositories) {
-      if (repository.recordId) {
-        logger.info(`Linking repository ${repository.id} to creator record ${newRecord.id}`);
-        await linkRecords(repository.recordId, newRecord.id, 'created_by', db);
+      if (!newRecord) {
+        throw new Error('Failed to create record');
       }
-    }
-  }
+
+      logger.info(`Created record ${newRecord.id} for ${user.login} (${user.id})`);
+
+      await db
+        .update(githubUsers)
+        .set({ recordId: newRecord.id })
+        .where(eq(githubUsers.id, user.id));
+
+      // Link repositories to creator
+      for (const repository of user.repositories) {
+        if (repository.recordId) {
+          logger.info(`Linking repository ${repository.id} to creator record ${newRecord.id}`);
+          await linkRecords(repository.recordId, newRecord.id, 'created_by', db);
+        }
+      }
+    },
+  });
+  throwPoolFailures(results, 'createRecordsFromGithubUsers', unmappedUsers.length);
 
   logger.complete(`Processed ${unmappedUsers.length} GitHub users`);
 }
@@ -159,33 +166,38 @@ export async function createRecordsFromGithubRepositories() {
 
   logger.info(`Found ${unmappedRepositories.length} unmapped GitHub repositories`);
 
-  for (const repository of unmappedRepositories) {
-    const newRecordDefaults = mapGithubRepositoryToRecord(repository);
+  const results = await runConcurrentPool({
+    items: unmappedRepositories,
+    concurrency: DB_CONCURRENCY,
+    worker: async (repository) => {
+      const newRecordDefaults = mapGithubRepositoryToRecord(repository);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(newRecordDefaults)
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(newRecordDefaults)
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
+      if (!newRecord) {
+        throw new Error('Failed to create record');
+      }
 
-    logger.info(`Created record ${newRecord.id} for ${repository.name} (${repository.id})`);
+      logger.info(`Created record ${newRecord.id} for ${repository.name} (${repository.id})`);
 
-    await db
-      .update(githubRepositories)
-      .set({ recordId: newRecord.id })
-      .where(eq(githubRepositories.id, repository.id));
+      await db
+        .update(githubRepositories)
+        .set({ recordId: newRecord.id })
+        .where(eq(githubRepositories.id, repository.id));
 
-    // Link repository to owner
-    if (repository.owner.recordId) {
-      logger.info(
-        `Linking repository ${repository.id} to creator record ${repository.owner.recordId}`
-      );
-      await linkRecords(newRecord.id, repository.owner.recordId, 'created_by', db);
-    }
-  }
+      // Link repository to owner
+      if (repository.owner.recordId) {
+        logger.info(
+          `Linking repository ${repository.id} to creator record ${repository.owner.recordId}`
+        );
+        await linkRecords(newRecord.id, repository.owner.recordId, 'created_by', db);
+      }
+    },
+  });
+  throwPoolFailures(results, 'createRecordsFromGithubRepositories', unmappedRepositories.length);
 
   logger.complete(`Processed ${unmappedRepositories.length} GitHub repositories`);
 }

--- a/src/server/integrations/github/octokit.ts
+++ b/src/server/integrations/github/octokit.ts
@@ -1,0 +1,32 @@
+import { throttling } from '@octokit/plugin-throttling';
+import { Octokit } from '@octokit/rest';
+import { createIntegrationLogger } from '../common/logging';
+
+const logger = createIntegrationLogger('github', 'api');
+
+const ThrottledOctokit = Octokit.plugin(throttling);
+
+/**
+ * Creates an authenticated Octokit client that respects GitHub's primary and
+ * secondary rate limits reactively: throttled requests are retried after the
+ * server-indicated delay instead of pacing every request with fixed sleeps.
+ */
+export function createGithubClient() {
+  return new ThrottledOctokit({
+    auth: process.env.GITHUB_TOKEN,
+    throttle: {
+      onRateLimit: (retryAfter, options, _octokit, retryCount) => {
+        logger.warn(
+          `Rate limit hit for ${options.method} ${options.url}; retrying after ${retryAfter}s`
+        );
+        return retryCount < 2;
+      },
+      onSecondaryRateLimit: (retryAfter, options, _octokit, retryCount) => {
+        logger.warn(
+          `Secondary rate limit hit for ${options.method} ${options.url}; retrying after ${retryAfter}s`
+        );
+        return retryCount < 2;
+      },
+    },
+  });
+}

--- a/src/server/integrations/github/sync-commits.ts
+++ b/src/server/integrations/github/sync-commits.ts
@@ -7,11 +7,12 @@ import {
   type GithubRepositoryInsert,
 } from '@hozo';
 import { RequestError } from '@octokit/request-error';
-import { Octokit } from '@octokit/rest';
 import type { Endpoints } from '@octokit/types';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
 import { logRateLimitInfo } from '../common/log-rate-limit-info';
 import { createIntegrationLogger } from '../common/logging';
+import { createGithubClient } from './octokit';
 import { syncCommitSummaries } from './summarize-commits';
 import { ensureGithubUserExists } from './sync-users';
 
@@ -21,13 +22,14 @@ const logger = createIntegrationLogger('github', 'sync-commits');
  * Type definitions
  */
 type GithubRepository = Endpoints['GET /repos/{owner}/{repo}']['response']['data'];
+type CommitSearchItem = Endpoints['GET /search/commits']['response']['data']['items'][number];
 
 /**
  * Configuration constants
  */
 const MAX_PATCH_LENGTH = 2048;
 const PER_PAGE = 100;
-const REQUEST_DELAY_MS = 1000;
+const COMMIT_CONCURRENCY = 8;
 
 /**
  * Retrieves the most recent commit date from the database
@@ -100,17 +102,9 @@ async function ensureRepositoryExists(
     contentUpdatedAt: new Date(repoData.updated_at),
   };
 
-  // First try to get existing repository to preserve starredAt
-  const existingRepo = await db.query.githubRepositories.findFirst({
-    columns: {
-      starredAt: true,
-    },
-    where: {
-      id: repoData.id,
-    },
-  });
-
-  // Insert or update the repository
+  // starredAt is deliberately absent from the update set so a star date
+  // written by the stars sync survives commit-driven upserts, including when
+  // the two syncs run concurrently.
   await db
     .insert(githubRepositories)
     .values(newRepo)
@@ -119,8 +113,6 @@ async function ensureRepositoryExists(
       set: {
         ...newRepo,
         recordUpdatedAt: new Date(),
-        // Only include starredAt if it exists in the database
-        ...(existingRepo?.starredAt && { starredAt: existingRepo.starredAt }),
       },
     });
 
@@ -147,9 +139,7 @@ async function syncGitHubCommits(
   collectDebugData?: unknown[],
   skipPersist = false
 ): Promise<number> {
-  const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
-  });
+  const octokit = createGithubClient();
 
   logger.start('Fetching GitHub commits');
 
@@ -163,11 +153,107 @@ async function syncGitHubCommits(
     logger.info('No existing commits in database');
   }
 
+  // Memoize per-run repository fetches and upserts: a push often lands many
+  // commits in the same repository.
+  const repositoryDataCache = new Map<string, Promise<GithubRepository>>();
+  const getRepositoryData = (owner: string, repo: string): Promise<GithubRepository> => {
+    const key = `${owner}/${repo}`;
+    let cached = repositoryDataCache.get(key);
+    if (!cached) {
+      cached = octokit.rest.repos.get({ owner, repo }).then((response) => {
+        logRateLimitInfo(response, logger);
+        return response.data;
+      });
+      repositoryDataCache.set(key, cached);
+    }
+    return cached;
+  };
+
+  const ensuredRepositories = new Map<number, Promise<number>>();
+  const ensureRepositoryOnce = (repoData: GithubRepository): Promise<number> => {
+    let ensured = ensuredRepositories.get(repoData.id);
+    if (!ensured) {
+      ensured = ensureRepositoryExists(repoData, integrationRunId);
+      ensuredRepositories.set(repoData.id, ensured);
+    }
+    return ensured;
+  };
+
+  const processCommitItem = async (item: CommitSearchItem): Promise<'inserted' | 'skipped'> => {
+    try {
+      // Get the full repository data
+      const repoData = await getRepositoryData(item.repository.owner.login, item.repository.name);
+
+      // Skip if this is a fork and the commit is older than the fork date
+      if (repoData.fork && new Date(item.commit.author.date) < new Date(repoData.created_at)) {
+        logger.info(`Skipping commit ${item.sha} as it predates fork creation`);
+        return 'skipped';
+      }
+
+      // Get detailed commit info including file changes
+      const detailedCommit = await octokit.rest.repos.getCommit({
+        owner: item.repository.owner.login,
+        repo: item.repository.name,
+        ref: item.sha,
+      });
+      logRateLimitInfo(detailedCommit, logger);
+
+      // In debug mode, just count the commits without persisting
+      if (skipPersist) {
+        logger.info(`Would insert commit ${item.sha} for ${item.repository.full_name}`);
+        return 'inserted';
+      }
+
+      // Ensure repository exists in database
+      await ensureRepositoryOnce(repoData);
+
+      // Insert new commit
+      const newCommit: GithubCommitInsert = {
+        id: item.node_id,
+        sha: item.sha,
+        message: item.commit.message,
+        htmlUrl: item.html_url,
+        repositoryId: item.repository.id,
+        committedAt: item.commit.committer?.date ? new Date(item.commit.committer.date) : null,
+        contentCreatedAt: new Date(item.commit.author.date),
+        integrationRunId,
+        changes: detailedCommit.data.stats?.total ?? null,
+        additions: detailedCommit.data.stats?.additions ?? null,
+        deletions: detailedCommit.data.stats?.deletions ?? null,
+      };
+
+      await db.insert(githubCommits).values(newCommit);
+
+      // Insert commit changes
+      const files = detailedCommit.data.files ?? [];
+      if (files.length > 0) {
+        const newChanges: GithubCommitChangeInsert[] = files.map((file) => ({
+          filename: file.filename,
+          status: file.status,
+          patch: file.patch ? file.patch.slice(0, MAX_PATCH_LENGTH) : '',
+          commitId: item.node_id,
+          changes: file.changes,
+          additions: file.additions,
+          deletions: file.deletions,
+        }));
+        await db.insert(githubCommitChanges).values(newChanges);
+      }
+
+      logger.info(`Inserted commit ${item.sha} for ${item.repository.full_name}`);
+      return 'inserted';
+    } catch (error) {
+      logger.error(`Error processing commit ${item.sha}`, {
+        error: error instanceof Error ? error.message : String(error),
+        repository: item.repository.full_name,
+      });
+      return 'skipped';
+    }
+  };
+
   let page = 1;
-  let hasMore = true;
   let totalCommits = 0;
 
-  while (hasMore) {
+  while (true) {
     try {
       logger.info(`Fetching page ${page}...`);
 
@@ -196,128 +282,39 @@ async function syncGitHubCommits(
 
       // Check if we've reached the end of the results
       if (response.data.items.length === 0) {
-        hasMore = false;
         break;
       }
 
-      // Process commits sequentially with rate limiting
-      let newCommitsOnPage = 0;
-      let processedAnyNewCommits = false;
-
-      for (let i = 0; i < response.data.items.length; i++) {
-        const item = response.data.items[i];
-        if (!item) {
-          logger.warn(`Missing commit item at index ${i} on page ${page}`);
-          continue;
+      // One bulk existence check per page instead of one query per commit
+      let newItems: CommitSearchItem[] = [...response.data.items];
+      if (!skipPersist) {
+        const existingCommits = await db.query.githubCommits.findMany({
+          columns: { sha: true },
+          where: { sha: { in: newItems.map((item) => item.sha) } },
+        });
+        const existingShas = new Set(existingCommits.map((commit) => commit.sha));
+        if (existingShas.size > 0) {
+          logger.info(`Skipping ${existingShas.size} existing commits on page ${page}`);
+          newItems = newItems.filter((item) => !existingShas.has(item.sha));
         }
-        try {
-          // In debug mode, skip DB existence check
-          if (!skipPersist) {
-            const existingCommit = await db.query.githubCommits.findFirst({
-              columns: { id: true, sha: true },
-              where: { sha: item.sha },
-            });
-
-            if (existingCommit) {
-              logger.info(`Skipping existing commit ${item.sha}`);
-              await Bun.sleep(REQUEST_DELAY_MS);
-              continue;
-            }
-          }
-
-          // Get the full repository data
-          const repoResponse = await octokit.rest.repos.get({
-            owner: item.repository.owner.login,
-            repo: item.repository.name,
-          });
-          logRateLimitInfo(repoResponse, logger);
-
-          // Skip if this is a fork and the commit is older than the fork date
-          if (repoResponse.data.fork) {
-            const commitDate = new Date(item.commit.author.date);
-            const forkDate = new Date(repoResponse.data.created_at);
-
-            if (commitDate < forkDate) {
-              logger.info(`Skipping commit ${item.sha} as it predates fork creation`);
-              await Bun.sleep(REQUEST_DELAY_MS);
-              continue;
-            }
-          }
-
-          // Get detailed commit info including file changes
-          const detailedCommit = await octokit.rest.repos.getCommit({
-            owner: item.repository.owner.login,
-            repo: item.repository.name,
-            ref: item.sha,
-          });
-          logRateLimitInfo(detailedCommit, logger);
-
-          processedAnyNewCommits = true;
-
-          // In debug mode, just count the commits without persisting
-          if (skipPersist) {
-            logger.info(`Would insert commit ${item.sha} for ${item.repository.full_name}`);
-            newCommitsOnPage++;
-            await Bun.sleep(REQUEST_DELAY_MS);
-            continue;
-          }
-
-          // Ensure repository exists in database
-          await ensureRepositoryExists(repoResponse.data, integrationRunId);
-
-          // Insert new commit
-          const newCommit: GithubCommitInsert = {
-            id: item.node_id,
-            sha: item.sha,
-            message: item.commit.message,
-            htmlUrl: item.html_url,
-            repositoryId: item.repository.id,
-            committedAt: item.commit.committer?.date ? new Date(item.commit.committer.date) : null,
-            contentCreatedAt: new Date(item.commit.author.date),
-            integrationRunId,
-            changes: detailedCommit.data.stats?.total ?? null,
-            additions: detailedCommit.data.stats?.additions ?? null,
-            deletions: detailedCommit.data.stats?.deletions ?? null,
-          };
-
-          await db.insert(githubCommits).values(newCommit);
-
-          // Insert commit changes
-          for (const file of detailedCommit.data.files || []) {
-            const newChange: GithubCommitChangeInsert = {
-              filename: file.filename,
-              status: file.status,
-              patch: file.patch ? file.patch.slice(0, MAX_PATCH_LENGTH) : '',
-              commitId: item.node_id,
-              changes: file.changes,
-              additions: file.additions,
-              deletions: file.deletions,
-            };
-            await db.insert(githubCommitChanges).values(newChange);
-          }
-
-          logger.info(`Inserted commit ${item.sha} for ${item.repository.full_name}`);
-          newCommitsOnPage++;
-          await Bun.sleep(REQUEST_DELAY_MS);
-        } catch (error) {
-          logger.error(`Error processing commit ${item.sha}`, {
-            error: error instanceof Error ? error.message : String(error),
-            repository: item.repository?.full_name,
-          });
-          await Bun.sleep(REQUEST_DELAY_MS);
-        }
-
-        logger.info(`Processing commits: ${i + 1}/${response.data.items.length}`);
       }
 
-      totalCommits += newCommitsOnPage;
-
-      // If we didn't process any new commits on this page, we can stop
-      if (!processedAnyNewCommits) {
+      if (newItems.length === 0) {
         logger.info('No new commits found on this page, stopping pagination');
-        hasMore = false;
         break;
       }
+
+      const results = await runConcurrentPool({
+        items: newItems,
+        concurrency: COMMIT_CONCURRENCY,
+        worker: (item) => processCommitItem(item),
+        onProgress: (completed, total) => {
+          if (completed % 10 === 0 || completed === total) {
+            logger.info(`Processing commits: ${completed}/${total}`);
+          }
+        },
+      });
+      totalCommits += results.filter((result) => result.ok && result.value === 'inserted').length;
 
       logger.info(`Processed new commits from page ${page}`);
       page++;

--- a/src/server/integrations/github/sync-stars.ts
+++ b/src/server/integrations/github/sync-stars.ts
@@ -1,9 +1,11 @@
 import { githubRepositories, type GithubRepositoryInsert } from '@hozo';
 import { RequestError } from '@octokit/request-error';
-import { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
 import { logRateLimitInfo } from '../common/log-rate-limit-info';
 import { createIntegrationLogger } from '../common/logging';
+import { createGithubClient } from './octokit';
 import { ensureGithubUserExists } from './sync-users';
 import { GithubStarredReposResponseSchema, type StarredRepo } from './types';
 
@@ -12,8 +14,8 @@ const logger = createIntegrationLogger('github', 'sync-stars');
 /**
  * Configuration constants
  */
-const PAGE_SIZE = 50;
-const REQUEST_DELAY_MS = 1000;
+const PAGE_SIZE = 100;
+const DB_CONCURRENCY = 10;
 
 /**
  * Retrieves the most recent starred date from the database
@@ -44,7 +46,7 @@ async function getMostRecentStarredAt(): Promise<Date | null> {
 }
 
 /**
- * Processes a single starred repository
+ * Upserts a single starred repository; its owner must already exist
  *
  * @param star - The starred repo data from the API
  * @param integrationRunId - The ID of the current integration run
@@ -54,10 +56,6 @@ async function processStarredRepo(star: StarredRepo, integrationRunId: number): 
   const { repo, starred_at } = star;
 
   try {
-    // First ensure the owner exists using shared helper
-    await ensureGithubUserExists(repo.owner, integrationRunId);
-
-    // Then insert the repository
     const newRepo: GithubRepositoryInsert = {
       id: repo.id,
       nodeId: repo.node_id,
@@ -140,9 +138,7 @@ export async function syncGitHubStars(
   collectDebugData?: unknown[],
   skipPersist = false
 ): Promise<number> {
-  const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
-  });
+  const octokit = createGithubClient();
 
   logger.start('Fetching GitHub starred repos');
 
@@ -154,7 +150,7 @@ export async function syncGitHubStars(
     logger.info('No existing stars in database');
   }
 
-  // Collect all new starred repos first, respecting rate limits during pagination
+  // Collect all new starred repos first
   const allNewStars: StarredRepo[] = [];
   let page = 1;
   let hasMore = true;
@@ -201,9 +197,6 @@ export async function syncGitHubStars(
       allNewStars.push(...newStarsOnPage);
 
       logger.info(`Found ${newStarsOnPage.length} new stars on page ${page}`);
-
-      // Rate limit delay between API requests
-      await Bun.sleep(REQUEST_DELAY_MS);
       page++;
     } catch (error) {
       if (error instanceof RequestError) {
@@ -231,21 +224,29 @@ export async function syncGitHubStars(
     return allNewStars.length;
   }
 
-  let successCount = 0;
-  for (let i = 0; i < allNewStars.length; i++) {
-    const star = allNewStars[i];
-    if (!star) {
-      continue;
-    }
-    const result = await processStarredRepo(star, integrationRunId);
-    if (result) successCount++;
-
-    if ((i + 1) % 10 === 0 || i + 1 === allNewStars.length) {
-      logger.info(`Processed ${i + 1}/${allNewStars.length} starred repos`);
-    }
-
-    await Bun.sleep(REQUEST_DELAY_MS);
+  // Upsert each unique owner once, then the repositories concurrently
+  const ownersById = new Map<number, StarredRepo['repo']['owner']>();
+  for (const star of allNewStars) {
+    ownersById.set(star.repo.owner.id, star.repo.owner);
   }
+  await runConcurrentPool({
+    items: [...ownersById.values()],
+    concurrency: DB_CONCURRENCY,
+    worker: (owner) => ensureGithubUserExists(owner, integrationRunId),
+  });
+
+  const results = await runConcurrentPool({
+    items: allNewStars,
+    concurrency: DB_CONCURRENCY,
+    worker: (star) => processStarredRepo(star, integrationRunId),
+    onProgress: (completed, total) => {
+      if (completed % 25 === 0 || completed === total) {
+        logger.info(`Processed ${completed}/${total} starred repos`);
+      }
+    },
+  });
+  const successCount = results.filter((result) => result.ok && result.value).length;
+
   logger.complete('Synced starred repositories', successCount);
   return successCount;
 }

--- a/src/server/integrations/github/sync-users.ts
+++ b/src/server/integrations/github/sync-users.ts
@@ -1,17 +1,18 @@
 import { githubUsers, type GithubUserInsert } from '@hozo';
 import { RequestError } from '@octokit/request-error';
-import { Octokit } from '@octokit/rest';
 import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
 import { logRateLimitInfo } from '../common/log-rate-limit-info';
 import { createIntegrationLogger } from '../common/logging';
+import { createGithubClient } from './octokit';
 
 const logger = createIntegrationLogger('github', 'sync-users');
 
 /**
  * Configuration constants
  */
-const REQUEST_DELAY_MS = 1000;
+const USER_CONCURRENCY = 10;
 
 /**
  * Ensures a GitHub user exists in the database
@@ -70,12 +71,10 @@ export async function ensureGithubUserExists(
  * 3. Updates the user records with the full information
  *
  * @returns The number of users successfully updated
- * @throws Error if the GitHub API request fails due to rate limiting
+ * @throws Error if a non-API failure (e.g. database error) occurs
  */
 export async function updatePartialUsers(): Promise<number> {
-  const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
-  });
+  const octokit = createGithubClient();
 
   logger.start('Fetching full user information for partial users');
 
@@ -96,68 +95,76 @@ export async function updatePartialUsers(): Promise<number> {
     return 0;
   }
 
-  let updatedCount = 0;
-
-  for (const user of partialUsers) {
-    try {
-      logger.info(`Fetching full information for user ${user.login}...`);
-      const response = await octokit.rest.users.getByUsername({
-        username: user.login,
-        headers: {
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      });
-
-      logRateLimitInfo(response, logger);
-
-      const userData = response.data;
-
-      await db
-        .update(githubUsers)
-        .set({
-          name: userData.name,
-          company: userData.company,
-          blog: userData.blog,
-          location: userData.location,
-          email: userData.email,
-          bio: userData.bio,
-          twitterUsername: userData.twitter_username,
-          followers: userData.followers,
-          following: userData.following,
-          contentCreatedAt: new Date(userData.created_at),
-          contentUpdatedAt: new Date(userData.updated_at),
-          partial: false,
-          recordUpdatedAt: new Date(),
-        })
-        .where(eq(githubUsers.id, user.id));
-
-      updatedCount++;
-      logger.info(`Updated user ${user.login} (${updatedCount}/${partialUsers.length})`);
-
-      await Bun.sleep(REQUEST_DELAY_MS);
-    } catch (error) {
-      if (error instanceof RequestError) {
-        logger.error(`Error fetching user ${user.login}`, {
-          status: error.status,
-          message: error.message,
-          headers: error.response?.headers,
+  const results = await runConcurrentPool({
+    items: partialUsers,
+    concurrency: USER_CONCURRENCY,
+    worker: async (user) => {
+      try {
+        const response = await octokit.rest.users.getByUsername({
+          username: user.login,
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
         });
 
-        if (error.response) {
-          logRateLimitInfo(error.response, logger);
-        }
+        logRateLimitInfo(response, logger);
 
-        if (error.status === 403 || error.status === 429) {
-          throw new Error(`GitHub API rate limit exceeded: ${error.message}`);
-        }
+        const userData = response.data;
 
-        logger.warn(`Skipping user ${user.login} due to error`);
-        continue;
+        await db
+          .update(githubUsers)
+          .set({
+            name: userData.name,
+            company: userData.company,
+            blog: userData.blog,
+            location: userData.location,
+            email: userData.email,
+            bio: userData.bio,
+            twitterUsername: userData.twitter_username,
+            followers: userData.followers,
+            following: userData.following,
+            contentCreatedAt: new Date(userData.created_at),
+            contentUpdatedAt: new Date(userData.updated_at),
+            partial: false,
+            recordUpdatedAt: new Date(),
+          })
+          .where(eq(githubUsers.id, user.id));
+
+        logger.info(`Updated user ${user.login}`);
+        return true;
+      } catch (error) {
+        if (error instanceof RequestError) {
+          logger.error(`Error fetching user ${user.login}`, {
+            status: error.status,
+            message: error.message,
+            headers: error.response?.headers,
+          });
+
+          if (error.response) {
+            logRateLimitInfo(error.response, logger);
+          }
+
+          logger.warn(`Skipping user ${user.login} due to error`);
+          return false;
+        }
+        throw error;
       }
-      throw error;
-    }
+    },
+    onProgress: (completed, total) => {
+      if (completed % 10 === 0 || completed === total) {
+        logger.info(`Progress: ${completed}/${total} users`);
+      }
+    },
+  });
+
+  // API errors skip the individual user; anything else (e.g. a database
+  // failure) is systemic and should abort the run
+  const firstFailure = results.find((result) => !result.ok);
+  if (firstFailure && !firstFailure.ok) {
+    throw firstFailure.error;
   }
 
+  const updatedCount = results.filter((result) => result.ok && result.value).length;
   logger.complete('Updated users with full information', updatedCount);
   return updatedCount;
 }

--- a/src/server/integrations/github/sync.ts
+++ b/src/server/integrations/github/sync.ts
@@ -1,3 +1,4 @@
+import { withBufferedLogs } from '../common/buffered-logs';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -9,16 +10,29 @@ import { updatePartialUsers } from './sync-users';
 const logger = createIntegrationLogger('github', 'sync');
 
 /**
+ * Runs independent sync steps concurrently, buffering each step's logs so
+ * they emit as contiguous blocks, and surfacing the first failure only after
+ * every step has settled.
+ */
+async function runConcurrentSteps(steps: Array<() => Promise<unknown>>): Promise<void> {
+  const settled = await Promise.allSettled(steps.map((step) => withBufferedLogs(step)));
+  for (const result of settled) {
+    if (result.status === 'rejected') {
+      throw result.reason;
+    }
+  }
+}
+
+/**
  * Orchestrates the GitHub data synchronization process
  *
  * This function coordinates the execution of multiple GitHub integration steps:
- * 1. Syncs starred repositories
- * 2. Syncs commit history
- * 3. Updates user information
- * 4. Creates records from GitHub users
- * 5. Creates records from GitHub repositories
+ * 1. Syncs starred repositories and commit history (independent, run concurrently)
+ * 2. Updates user information for users created by either sync
+ * 3. Creates records from GitHub users
+ * 4. Creates records from GitHub repositories
  *
- * Each step is wrapped in the runIntegration utility to track execution.
+ * Each sync is wrapped in the runIntegration utility to track execution.
  *
  * @param debug - If true, fetches data and outputs to .temp/ without writing to database
  * @returns Promise that resolves when all GitHub data is synced
@@ -37,25 +51,26 @@ async function syncGitHubData(debug = false): Promise<void> {
     if (debug) {
       // Debug mode: fetch data and output to .temp/ only, skip database writes
       logger.start('Starting GitHub data fetch (debug mode - no database writes)');
-      await syncGitHubStars(-1, debugContext.data?.stars, true);
-      await syncGitHubCommits(-1, debugContext.data?.commits, true);
+      await runConcurrentSteps([
+        () => syncGitHubStars(-1, debugContext.data?.stars, true),
+        () => syncGitHubCommits(-1, debugContext.data?.commits, true),
+      ]);
       logger.complete('GitHub data fetch completed (debug mode)');
     } else {
       // Normal mode: full sync with database writes
       logger.start('Starting GitHub data synchronization');
 
-      // Step 1: Sync starred repositories
-      await runIntegration('github', (runId) => syncGitHubStars(runId, debugContext.data?.stars));
+      // Step 1: Sync starred repositories and commit history concurrently
+      await runConcurrentSteps([
+        () => runIntegration('github', (runId) => syncGitHubStars(runId, debugContext.data?.stars)),
+        () =>
+          runIntegration('github', (runId) => syncGitHubCommits(runId, debugContext.data?.commits)),
+      ]);
 
-      // Step 2: Sync commit history
-      await runIntegration('github', (runId) =>
-        syncGitHubCommits(runId, debugContext.data?.commits)
-      );
-
-      // Step 3: Update user information
+      // Step 2: Update user information
       await updatePartialUsers();
 
-      // Step 4-5: Create records from GitHub entities
+      // Step 3-4: Create records from GitHub entities
       await createRecordsFromGithubUsers();
       await createRecordsFromGithubRepositories();
 

--- a/src/server/integrations/raindrop/map.ts
+++ b/src/server/integrations/raindrop/map.ts
@@ -16,8 +16,12 @@ import {
 import { eq, inArray } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { getMediaInsertData, uploadMediaToR2 } from '@/server/lib/media';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { linkRecords } from '../common/db-helpers';
 import { createIntegrationLogger } from '../common/logging';
+
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 
 const logger = createIntegrationLogger('raindrop', 'map');
 
@@ -88,30 +92,35 @@ export async function createRaindropTags(integrationRunId?: number) {
   }
 
   // Create new bookmark-tag relationships
-  const bookmarkTagPromises = bookmarks.flatMap((bookmark) => {
+  const bookmarkTagRows = bookmarks.flatMap((bookmark) => {
     if (!bookmark.tags) return [];
 
-    return bookmark.tags.map(async (tag) => {
-      const tagId = tagMap.get(tag);
-      if (!tagId) return null;
-
-      const [bookmarkTag] = await db
-        .insert(raindropBookmarkTags)
-        .values({ bookmarkId: bookmark.id, tagId })
-        .onConflictDoUpdate({
-          target: [raindropBookmarkTags.bookmarkId, raindropBookmarkTags.tagId],
-          set: {
-            recordUpdatedAt: new Date(),
-          },
-        })
-        .returning();
-
-      return bookmarkTag;
-    });
+    return bookmark.tags
+      .map((tag) => {
+        const tagId = tagMap.get(tag);
+        if (!tagId) return null;
+        return { bookmarkId: bookmark.id, tagId };
+      })
+      .filter((row): row is { bookmarkId: number; tagId: number } => row !== null);
   });
 
-  const newBookmarkTags = (await Promise.all(bookmarkTagPromises)).filter(Boolean);
-  logger.info(`Inserted ${newBookmarkTags.length} bookmark tags`);
+  const BULK_INSERT_CHUNK_SIZE = 1000;
+  let insertedCount = 0;
+  for (let i = 0; i < bookmarkTagRows.length; i += BULK_INSERT_CHUNK_SIZE) {
+    const chunk = bookmarkTagRows.slice(i, i + BULK_INSERT_CHUNK_SIZE);
+    const inserted = await db
+      .insert(raindropBookmarkTags)
+      .values(chunk)
+      .onConflictDoUpdate({
+        target: [raindropBookmarkTags.bookmarkId, raindropBookmarkTags.tagId],
+        set: {
+          recordUpdatedAt: new Date(),
+        },
+      })
+      .returning();
+    insertedCount += inserted.length;
+  }
+  logger.info(`Inserted ${insertedCount} bookmark tags`);
 
   logger.complete(`Processed tags for ${bookmarks.length} bookmarks`);
   return bookmarks;
@@ -162,43 +171,51 @@ export async function createRecordsFromRaindropBookmarks() {
 
   logger.info(`Found ${unmappedBookmarks.length} unmapped Raindrop bookmarks`);
 
-  for (const bookmark of unmappedBookmarks) {
-    const newRecordDefaults = mapRaindropBookmarkToRecord(bookmark);
+  let processed = 0;
+  const bookmarkResults = await runConcurrentPool({
+    items: unmappedBookmarks,
+    concurrency: DB_CONCURRENCY,
+    async worker(bookmark) {
+      const newRecordDefaults = mapRaindropBookmarkToRecord(bookmark);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(newRecordDefaults)
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(newRecordDefaults)
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
-
-    logger.info(`Created record ${newRecord.id} for bookmark ${bookmark.title} (${bookmark.id})`);
-
-    await db
-      .update(raindropBookmarks)
-      .set({ recordId: newRecord.id })
-      .where(eq(raindropBookmarks.id, bookmark.id));
-
-    // Link tags to the record
-    for (const tag of bookmark.tagRecords) {
-      if (tag.recordId) {
-        logger.info(`Linking record ${newRecord.id} to tag ${tag.recordId}`);
-        await linkRecords(newRecord.id, tag.recordId, 'tagged_with', db);
+      if (!newRecord) {
+        throw new Error('Failed to create record');
       }
-    }
 
-    // Link media to the record if it exists
-    for (const image of bookmark.coverImages) {
-      if (image.mediaId) {
-        logger.info(`Linking media ${image.mediaId} to record ${newRecord.id}`);
-        await db.update(media).set({ recordId: newRecord.id }).where(eq(media.id, image.mediaId));
+      logger.info(`Created record ${newRecord.id} for bookmark ${bookmark.title} (${bookmark.id})`);
+
+      await db
+        .update(raindropBookmarks)
+        .set({ recordId: newRecord.id })
+        .where(eq(raindropBookmarks.id, bookmark.id));
+
+      // Link tags to the record
+      for (const tag of bookmark.tagRecords) {
+        if (tag.recordId) {
+          logger.info(`Linking record ${newRecord.id} to tag ${tag.recordId}`);
+          await linkRecords(newRecord.id, tag.recordId, 'tagged_with', db);
+        }
       }
-    }
-  }
 
-  logger.complete(`Processed ${unmappedBookmarks.length} Raindrop bookmarks`);
+      // Link media to the record if it exists
+      for (const image of bookmark.coverImages) {
+        if (image.mediaId) {
+          logger.info(`Linking media ${image.mediaId} to record ${newRecord.id}`);
+          await db.update(media).set({ recordId: newRecord.id }).where(eq(media.id, image.mediaId));
+        }
+      }
+
+      processed++;
+    },
+  });
+  throwPoolFailures(bookmarkResults, 'Raindrop bookmark→record mapping', unmappedBookmarks.length);
+
+  logger.complete(`Processed ${processed} of ${unmappedBookmarks.length} Raindrop bookmarks`);
 }
 
 const mapRaindropImageToMedia = async (
@@ -256,8 +273,10 @@ export async function createMediaFromRaindropBookmarks() {
 
   logger.info(`Found ${unmappedImages.length} Raindrop images without media`);
 
-  await Promise.all(
-    unmappedImages.map(async (image) => {
+  const mediaResults = await runConcurrentPool({
+    items: unmappedImages,
+    concurrency: DB_CONCURRENCY,
+    async worker(image) {
       const newMedia = await mapRaindropImageToMedia(image);
       if (!newMedia) {
         logger.warn(`Invalid image for image ${image.id}, deleting...`);
@@ -297,8 +316,9 @@ export async function createMediaFromRaindropBookmarks() {
           .set({ recordId: image.bookmark.recordId })
           .where(eq(media.id, newMediaRecord.id));
       }
-    })
-  );
+    },
+  });
+  throwPoolFailures(mediaResults, 'Raindrop media creation', unmappedImages.length);
 
   logger.complete(`Processed ${unmappedImages.length} Raindrop bookmark media`);
 }
@@ -345,42 +365,50 @@ export async function createRecordsFromRaindropTags() {
 
   logger.info(`Found ${unmappedTags.length} unmapped Raindrop tags`);
 
-  for (const tag of unmappedTags) {
-    const newCategoryDefaults = mapRaindropTagToRecord(tag);
+  let processed = 0;
+  const tagResults = await runConcurrentPool({
+    items: unmappedTags,
+    concurrency: DB_CONCURRENCY,
+    async worker(tag) {
+      const newCategoryDefaults = mapRaindropTagToRecord(tag);
 
-    const [newCategory] = await db
-      .insert(records)
-      .values(newCategoryDefaults)
-      .returning({ id: records.id })
-      .onConflictDoUpdate({
-        target: records.id,
-        set: {
-          recordUpdatedAt: new Date(),
-          isCurated: false,
-        },
-      });
+      const [newCategory] = await db
+        .insert(records)
+        .values(newCategoryDefaults)
+        .returning({ id: records.id })
+        .onConflictDoUpdate({
+          target: records.id,
+          set: {
+            recordUpdatedAt: new Date(),
+            isCurated: false,
+          },
+        });
 
-    if (!newCategory) {
-      throw new Error('Failed to create category');
-    }
-
-    logger.info(`Created record ${newCategory.id} for tag ${tag.tag}`);
-
-    await db
-      .update(raindropTags)
-      .set({ recordId: newCategory.id })
-      .where(eq(raindropTags.id, tag.id));
-
-    // Link bookmarks to the tag
-    for (const bookmark of tag.bookmarks) {
-      if (bookmark.recordId) {
-        logger.info(`Linking record ${bookmark.recordId} to category ${newCategory.id}`);
-        await linkRecords(bookmark.recordId, newCategory.id, 'tagged_with', db);
+      if (!newCategory) {
+        throw new Error('Failed to create category');
       }
-    }
-  }
 
-  logger.complete(`Processed ${unmappedTags.length} Raindrop tags`);
+      logger.info(`Created record ${newCategory.id} for tag ${tag.tag}`);
+
+      await db
+        .update(raindropTags)
+        .set({ recordId: newCategory.id })
+        .where(eq(raindropTags.id, tag.id));
+
+      // Link bookmarks to the tag
+      for (const bookmark of tag.bookmarks) {
+        if (bookmark.recordId) {
+          logger.info(`Linking record ${bookmark.recordId} to category ${newCategory.id}`);
+          await linkRecords(bookmark.recordId, newCategory.id, 'tagged_with', db);
+        }
+      }
+
+      processed++;
+    },
+  });
+  throwPoolFailures(tagResults, 'Raindrop tag→record mapping', unmappedTags.length);
+
+  logger.complete(`Processed ${processed} of ${unmappedTags.length} Raindrop tags`);
 }
 
 export const mapRaindropHighlightToRecord = (
@@ -432,44 +460,64 @@ export async function createRecordsFromRaindropHighlights() {
   // Map to store the new record IDs keyed by highlight ID
   const recordMap = new Map<string, number>();
 
-  for (const highlight of unmappedHighlights) {
-    const newRecordDefaults = mapRaindropHighlightToRecord(highlight);
+  const highlightResults = await runConcurrentPool({
+    items: unmappedHighlights,
+    concurrency: DB_CONCURRENCY,
+    async worker(highlight) {
+      const newRecordDefaults = mapRaindropHighlightToRecord(highlight);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(newRecordDefaults)
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(newRecordDefaults)
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
+      if (!newRecord) {
+        throw new Error('Failed to create record');
+      }
 
-    logger.info(
-      `Created record ${newRecord.id} for highlight ${highlight.text.slice(0, 30)}... (${highlight.id})`
-    );
+      logger.info(
+        `Created record ${newRecord.id} for highlight ${highlight.text.slice(0, 30)}... (${highlight.id})`
+      );
 
-    await db
-      .update(raindropHighlights)
-      .set({ recordId: newRecord.id })
-      .where(eq(raindropHighlights.id, highlight.id));
+      await db
+        .update(raindropHighlights)
+        .set({ recordId: newRecord.id })
+        .where(eq(raindropHighlights.id, highlight.id));
 
-    recordMap.set(highlight.id, newRecord.id);
-  }
+      recordMap.set(highlight.id, newRecord.id);
+    },
+  });
+  throwPoolFailures(
+    highlightResults,
+    'Raindrop highlight→record mapping',
+    unmappedHighlights.length
+  );
 
   // Link highlight records to their parent bookmark records via contained_by
-  for (const highlight of unmappedHighlights) {
-    const childRecordId = recordMap.get(highlight.id);
-    const parentRecordId = highlight.bookmark.recordId;
+  const parentLinkResults = await runConcurrentPool({
+    items: unmappedHighlights,
+    concurrency: DB_CONCURRENCY,
+    async worker(highlight) {
+      const childRecordId = recordMap.get(highlight.id);
+      const parentRecordId = highlight.bookmark.recordId;
 
-    if (childRecordId && parentRecordId) {
-      await linkRecords(childRecordId, parentRecordId, 'contained_by', db);
-      logger.info(`Linked highlight record ${childRecordId} to bookmark record ${parentRecordId}`);
-    } else {
-      logger.warn(
-        `Skipping linking for highlight ${highlight.id} due to missing record IDs (child: ${childRecordId}, parent: ${parentRecordId})`
-      );
-    }
-  }
+      if (childRecordId && parentRecordId) {
+        await linkRecords(childRecordId, parentRecordId, 'contained_by', db);
+        logger.info(
+          `Linked highlight record ${childRecordId} to bookmark record ${parentRecordId}`
+        );
+      } else {
+        logger.warn(
+          `Skipping linking for highlight ${highlight.id} due to missing record IDs (child: ${childRecordId}, parent: ${parentRecordId})`
+        );
+      }
+    },
+  });
+  throwPoolFailures(
+    parentLinkResults,
+    'Raindrop highlight parent linking',
+    unmappedHighlights.length
+  );
 
   logger.complete(`Processed ${unmappedHighlights.length} Raindrop highlights`);
 }

--- a/src/server/integrations/raindrop/sync.ts
+++ b/src/server/integrations/raindrop/sync.ts
@@ -9,6 +9,7 @@ import {
   type RaindropHighlightInsert,
 } from '@hozo';
 import { db } from '@/server/db/connections/postgres';
+import { withBufferedLogs } from '../common/buffered-logs';
 import { createDebugContext } from '../common/debug-output';
 import { requireEnv } from '../common/env';
 import { createIntegrationLogger } from '../common/logging';
@@ -387,11 +388,12 @@ async function processRaindrops(raindrops: Raindrop[], integrationRunId: number)
  * @param integrationRunId - The ID of the current integration run
  */
 async function createRelatedEntities(integrationRunId: number): Promise<void> {
-  // Create tags from raindrops
-  await createRaindropTags(integrationRunId);
+  // Create tags from raindrops and media from bookmarks (independent of each other)
+  await Promise.all([
+    withBufferedLogs(() => createRaindropTags(integrationRunId)),
+    withBufferedLogs(() => createMediaFromRaindropBookmarks()),
+  ]);
 
-  // Create media from bookmarks
-  await createMediaFromRaindropBookmarks();
   // Create records from tags
   await createRecordsFromRaindropTags();
   // Create main records

--- a/src/server/integrations/readwise/map.ts
+++ b/src/server/integrations/readwise/map.ts
@@ -491,9 +491,13 @@ export const mapReadwiseDocumentToRecord = (
 };
 
 /**
- * Creates records from Readwise documents that don't have associated records yet
+ * Creates records from Readwise documents that don't have associated records
+ * yet. When an integration run id is given, also refreshes author and tag
+ * links for already-mapped documents updated in that run — a tag added in
+ * Readwise to a previously synced document arrives as a document update, not
+ * a new document, and would otherwise never be linked.
  */
-export async function createRecordsFromReadwiseDocuments() {
+export async function createRecordsFromReadwiseDocuments(integrationRunId?: number) {
   logger.start('Creating records from Readwise documents');
 
   // Query readwise documents that need records created (skip notes-only docs)
@@ -528,12 +532,28 @@ export async function createRecordsFromReadwiseDocuments() {
     },
   });
 
-  if (documents.length === 0) {
+  const updatedMappedDocuments = integrationRunId
+    ? await db.query.readwiseDocuments.findMany({
+        where: {
+          integrationRunId,
+          recordId: {
+            isNotNull: true,
+          },
+          deletedAt: {
+            isNull: true,
+          },
+        },
+      })
+    : [];
+
+  if (documents.length === 0 && updatedMappedDocuments.length === 0) {
     logger.skip('No new or updated documents to process');
     return;
   }
 
-  logger.info(`Found ${documents.length} unmapped Readwise documents`);
+  logger.info(
+    `Found ${documents.length} unmapped and ${updatedMappedDocuments.length} updated Readwise documents`
+  );
 
   // Map to store the new record IDs keyed by the corresponding readwise document ID.
   const recordMap = new Map<string, number>();
@@ -613,9 +633,28 @@ export async function createRecordsFromReadwiseDocuments() {
   );
 
   // Step 3: Link records to index entries via recordCreators (for authors) and recordCategories (for tags).
+  // Covers both newly created records and already-mapped documents updated in
+  // this run; link upserts make relinking existing pairs a no-op.
+  const documentsToLink: Array<{
+    authorId: number | null;
+    tags: string[] | null;
+    recordId: number;
+  }> = [];
+  for (const doc of documents) {
+    const recordId = recordMap.get(doc.id);
+    if (recordId) {
+      documentsToLink.push({ authorId: doc.authorId, tags: doc.tags, recordId });
+    }
+  }
+  for (const doc of updatedMappedDocuments) {
+    if (doc.recordId) {
+      documentsToLink.push({ authorId: doc.authorId, tags: doc.tags, recordId: doc.recordId });
+    }
+  }
+
   // Build a map for authors.
   const authorIdsSet = new Set<number>();
-  for (const doc of documents) {
+  for (const doc of documentsToLink) {
     if (doc.authorId) {
       authorIdsSet.add(doc.authorId);
     }
@@ -640,7 +679,7 @@ export async function createRecordsFromReadwiseDocuments() {
 
   // Build a map for tags.
   const tagSet = new Set<string>();
-  for (const doc of documents) {
+  for (const doc of documentsToLink) {
     if (doc.tags) {
       doc.tags.forEach((tag) => tagSet.add(tag));
     }
@@ -667,9 +706,8 @@ export async function createRecordsFromReadwiseDocuments() {
   const recordCreatorsValues: LinkInsert[] = [];
   const recordRelationsValues: LinkInsert[] = [];
 
-  for (const doc of documents) {
-    const recordId = recordMap.get(doc.id);
-    if (!recordId) continue;
+  for (const doc of documentsToLink) {
+    const { recordId } = doc;
 
     // Link author via recordCreators.
     if (doc.authorId && authorIndexMap.has(doc.authorId)) {
@@ -713,5 +751,7 @@ export async function createRecordsFromReadwiseDocuments() {
     logger.info(`Linked ${recordRelationsValues.length} tags to records`);
   }
 
-  logger.complete(`Processed ${recordMap.size} Readwise documents`);
+  logger.complete(
+    `Processed ${recordMap.size} new and ${updatedMappedDocuments.length} updated Readwise documents`
+  );
 }

--- a/src/server/integrations/readwise/sync.ts
+++ b/src/server/integrations/readwise/sync.ts
@@ -366,7 +366,7 @@ async function syncReadwiseDocumentsInternal(integrationRunId: number): Promise<
           await createRecordsFromReadwiseTags();
         }),
       ]);
-      await createRecordsFromReadwiseDocuments();
+      await createRecordsFromReadwiseDocuments(integrationRunId);
     }
 
     logger.complete('Processed documents', successCount);

--- a/src/server/integrations/readwise/sync.ts
+++ b/src/server/integrations/readwise/sync.ts
@@ -1,5 +1,7 @@
 import { readwiseDocuments, type ReadwiseDocumentInsert } from '@hozo';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
+import { withBufferedLogs } from '../common/buffered-logs';
 import { createDebugContext } from '../common/debug-output';
 import { requireEnv } from '../common/env';
 import { createIntegrationLogger } from '../common/logging';
@@ -22,6 +24,8 @@ import {
  */
 const API_BASE_URL = 'https://readwise.io/api/v3/list/';
 const RETRY_DELAY_BASE = 1000; // 1 second in milliseconds
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 const READWISE_TOKEN = requireEnv('READWISE_TOKEN');
 const logger = createIntegrationLogger('readwise', 'sync');
 
@@ -196,39 +200,54 @@ const mapReadwiseArticleToDocument = (
 };
 
 /**
- * Sorts documents by their hierarchical relationship
- *
- * This ensures that parent documents are processed before their children.
- *
- * @param documents - The documents to sort
- * @returns Sorted array of documents
+ * Gets the depth of a document in the parent/child tree (0 for a root document)
  */
+function getDocumentDepth(
+  doc: ReadwiseArticle,
+  idToDocument: Map<string, ReadwiseArticle>
+): number {
+  let depth = 0;
+  let current = doc;
+  while (current.parent_id) {
+    const parent = idToDocument.get(current.parent_id);
+    if (!parent) break;
+    depth++;
+    current = parent;
+  }
+  return depth;
+}
+
 function sortDocumentsByHierarchy(documents: ReadwiseArticle[]): ReadwiseArticle[] {
   // Create a map of id to document for quick lookup
   const idToDocument = new Map(documents.map((doc) => [doc.id, doc]));
 
-  // Helper function to get the ancestry chain for a document
-  function getAncestryChain(doc: ReadwiseArticle): string[] {
-    const chain: string[] = [];
-    let current = doc;
-    while (current.parent_id) {
-      const parent = idToDocument.get(current.parent_id);
-      if (!parent) break;
-      chain.push(current.parent_id);
-      current = parent;
-    }
-    return chain;
-  }
-
   // Sort by ancestry chain length (parents first), then by creation date
   return [...documents].sort((a, b) => {
-    const aChain = getAncestryChain(a);
-    const bChain = getAncestryChain(b);
-    if (aChain.length !== bChain.length) {
-      return aChain.length - bChain.length;
+    const aDepth = getDocumentDepth(a, idToDocument);
+    const bDepth = getDocumentDepth(b, idToDocument);
+    if (aDepth !== bDepth) {
+      return aDepth - bDepth;
     }
     return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
   });
+}
+
+/**
+ * Groups documents by their depth in the parent/child tree so that each depth
+ * level can be inserted concurrently while still guaranteeing every ancestor
+ * is inserted before its descendants.
+ */
+function groupDocumentsByDepth(documents: ReadwiseArticle[]): ReadwiseArticle[][] {
+  const idToDocument = new Map(documents.map((doc) => [doc.id, doc]));
+
+  const levels: ReadwiseArticle[][] = [];
+  for (const doc of documents) {
+    const depth = getDocumentDepth(doc, idToDocument);
+    const level = levels[depth] ?? [];
+    level.push(doc);
+    levels[depth] = level;
+  }
+  return levels;
 }
 
 /**
@@ -299,39 +318,54 @@ async function syncReadwiseDocumentsInternal(integrationRunId: number): Promise<
       // Sort documents to ensure parents are processed before children
       const sortedDocuments = sortDocumentsByHierarchy(allDocuments);
 
-      // Process each document
-      for (const doc of sortedDocuments) {
-        try {
-          // Map and insert the document
-          const documentToInsert = mapReadwiseArticleToDocument(doc, integrationRunId);
-          await db
-            .insert(readwiseDocuments)
-            .values(documentToInsert)
-            .onConflictDoUpdate({
-              target: readwiseDocuments.id,
-              set: { ...documentToInsert, recordUpdatedAt: new Date() },
-            });
+      // Insert level by level (root documents first) so that inserts within a
+      // level can run concurrently while ancestors always land before descendants.
+      const documentLevels = groupDocumentsByDepth(sortedDocuments);
+      for (const level of documentLevels) {
+        await runConcurrentPool({
+          items: level,
+          concurrency: DB_CONCURRENCY,
+          async worker(doc) {
+            try {
+              // Map and insert the document
+              const documentToInsert = mapReadwiseArticleToDocument(doc, integrationRunId);
+              await db
+                .insert(readwiseDocuments)
+                .values(documentToInsert)
+                .onConflictDoUpdate({
+                  target: readwiseDocuments.id,
+                  set: { ...documentToInsert, recordUpdatedAt: new Date() },
+                });
 
-          successCount++;
+              successCount++;
 
-          // Log progress periodically
-          if (successCount % 20 === 0) {
-            logger.info(`Processed ${successCount} of ${sortedDocuments.length} documents`);
-          }
-        } catch (error) {
-          logger.error('Error processing document', {
-            documentId: doc.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
+              // Log progress periodically
+              if (successCount % 20 === 0) {
+                logger.info(`Processed ${successCount} of ${sortedDocuments.length} documents`);
+              }
+            } catch (error) {
+              logger.error('Error processing document', {
+                documentId: doc.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          },
+        });
       }
 
-      // Step 4: Create related entities
+      // Step 4: Create related entities.
+      // Authors and tags are independent dependency chains, so run them concurrently.
       logger.info('Creating related entities');
-      await createReadwiseAuthors();
-      await createReadwiseTags(integrationRunId);
-      await createRecordsFromReadwiseAuthors();
-      await createRecordsFromReadwiseTags();
+      await Promise.all([
+        withBufferedLogs(async () => {
+          await createReadwiseAuthors();
+          await createRecordsFromReadwiseAuthors();
+        }),
+        withBufferedLogs(async () => {
+          await createReadwiseTags(integrationRunId);
+          await createRecordsFromReadwiseTags();
+        }),
+      ]);
       await createRecordsFromReadwiseDocuments();
     }
 

--- a/src/server/integrations/twitter/client.ts
+++ b/src/server/integrations/twitter/client.ts
@@ -120,7 +120,7 @@ export class TwitterClient {
   /**
    * Fetches a single page of bookmarks.
    */
-  private async fetchBookmarksPage(cursor?: string, count = 20): Promise<BookmarksPageResponse> {
+  private async fetchBookmarksPage(cursor?: string, count = 50): Promise<BookmarksPageResponse> {
     const variables = {
       count,
       includePromotedContent: false,
@@ -299,7 +299,7 @@ export class TwitterClient {
    * Fetches all bookmarks with pagination.
    *
    * @param options.maxPages - Maximum number of pages to fetch (default: unlimited)
-   * @param options.pageSize - Number of items per page (default: 20)
+   * @param options.pageSize - Number of items per page (default: 50)
    * @param options.knownTweetIds - Set of tweet IDs already in database; stops when encountered
    * @returns Array of bookmark responses in the format expected by sync.ts
    */
@@ -308,7 +308,7 @@ export class TwitterClient {
     pageSize?: number;
     knownTweetIds?: Set<string>;
   }): Promise<TwitterBookmarksArray> {
-    const { maxPages, pageSize = 20, knownTweetIds } = options ?? {};
+    const { maxPages, pageSize = 50, knownTweetIds } = options ?? {};
     const responses: TwitterBookmarksArray = [];
     let cursor: string | undefined;
     let pagesFetched = 0;

--- a/src/server/integrations/twitter/client.ts
+++ b/src/server/integrations/twitter/client.ts
@@ -120,7 +120,7 @@ export class TwitterClient {
   /**
    * Fetches a single page of bookmarks.
    */
-  private async fetchBookmarksPage(cursor?: string, count = 50): Promise<BookmarksPageResponse> {
+  private async fetchBookmarksPage(cursor?: string, count = 20): Promise<BookmarksPageResponse> {
     const variables = {
       count,
       includePromotedContent: false,
@@ -299,7 +299,7 @@ export class TwitterClient {
    * Fetches all bookmarks with pagination.
    *
    * @param options.maxPages - Maximum number of pages to fetch (default: unlimited)
-   * @param options.pageSize - Number of items per page (default: 50)
+   * @param options.pageSize - Number of items per page (default: 20)
    * @param options.knownTweetIds - Set of tweet IDs already in database; stops when encountered
    * @returns Array of bookmark responses in the format expected by sync.ts
    */
@@ -308,7 +308,7 @@ export class TwitterClient {
     pageSize?: number;
     knownTweetIds?: Set<string>;
   }): Promise<TwitterBookmarksArray> {
-    const { maxPages, pageSize = 50, knownTweetIds } = options ?? {};
+    const { maxPages, pageSize = 20, knownTweetIds } = options ?? {};
     const responses: TwitterBookmarksArray = [];
     let cursor: string | undefined;
     let pagesFetched = 0;

--- a/src/server/integrations/twitter/map.ts
+++ b/src/server/integrations/twitter/map.ts
@@ -4,6 +4,7 @@ import {
   twitterMedia,
   twitterTweets,
   twitterUsers,
+  type LinkInsert,
   type MediaInsert,
   type RecordInsert,
   type TwitterMediaSelect,
@@ -13,10 +14,14 @@ import {
 import { eq } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { getMediaInsertData, uploadMediaToR2 } from '@/server/lib/media';
+import { runConcurrentPool, throwPoolFailures } from '@/shared/lib/async-pool';
 import { decodeHtmlEntities } from '@/shared/lib/formatting';
-import { linkRecords } from '../common/db-helpers';
+import { bulkInsertLinks, linkRecords } from '../common/db-helpers';
 import { createIntegrationLogger } from '../common/logging';
 import { createUrlResolver, loadKnownTweetIds, normalizeTweetContent } from './tweet-text';
+
+/** Default concurrency for database operations */
+const DB_CONCURRENCY = 10;
 
 const logger = createIntegrationLogger('twitter', 'map');
 
@@ -69,29 +74,34 @@ export async function createRecordsFromTwitterUsers() {
 
   logger.info(`Found ${users.length} unmapped Twitter users`);
 
-  for (const user of users) {
-    const entity = mapTwitterUserToRecord(user);
+  const userResults = await runConcurrentPool({
+    items: users,
+    concurrency: DB_CONCURRENCY,
+    async worker(user) {
+      const entity = mapTwitterUserToRecord(user);
 
-    const [newRecord] = await db
-      .insert(records)
-      .values(entity)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
+      const [newRecord] = await db
+        .insert(records)
+        .values(entity)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: { recordUpdatedAt: new Date() },
+        })
+        .returning({ id: records.id });
 
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
+      if (!newRecord) {
+        throw new Error('Failed to create record');
+      }
 
-    await db
-      .update(twitterUsers)
-      .set({ recordId: newRecord.id })
-      .where(eq(twitterUsers.id, user.id));
+      await db
+        .update(twitterUsers)
+        .set({ recordId: newRecord.id })
+        .where(eq(twitterUsers.id, user.id));
 
-    logger.info(`Created record ${newRecord.id} for user ${user.username}`);
-  }
+      logger.info(`Created record ${newRecord.id} for user ${user.username}`);
+    },
+  });
+  throwPoolFailures(userResults, 'Twitter user→record mapping', users.length);
 
   logger.complete(`Processed ${users.length} Twitter users`);
 }
@@ -158,59 +168,64 @@ export async function createRecordsFromTweets() {
   // Map to store the new record IDs keyed by the corresponding Twitter tweet ID.
   const recordMap = new Map<string, number>();
 
-  for (const tweet of tweets) {
-    const decodedText = tweet.text ? decodeHtmlEntities(tweet.text).trim() : '';
-    // Include quoted tweet ID so its URL gets removed (relationship is tracked separately)
-    const additionalKnownIds = tweet.quotedTweet?.id ? [tweet.quotedTweet.id] : [];
-    const content = await normalizeTweetContent(decodedText, knownTweetIds, resolveUrl, {
-      additionalKnownIds,
-    });
-    const record = mapTwitterTweetToRecord(tweet, content);
+  const tweetResults = await runConcurrentPool({
+    items: tweets,
+    concurrency: DB_CONCURRENCY,
+    async worker(tweet) {
+      const decodedText = tweet.text ? decodeHtmlEntities(tweet.text).trim() : '';
+      // Include quoted tweet ID so its URL gets removed (relationship is tracked separately)
+      const additionalKnownIds = tweet.quotedTweet?.id ? [tweet.quotedTweet.id] : [];
+      const content = await normalizeTweetContent(decodedText, knownTweetIds, resolveUrl, {
+        additionalKnownIds,
+      });
+      const record = mapTwitterTweetToRecord(tweet, content);
 
-    // Insert the record with parentId set to null (to be updated later if this is a quote).
-    const [newRecord] = await db
-      .insert(records)
-      .values(record)
-      .onConflictDoUpdate({
-        target: records.id,
-        set: { recordUpdatedAt: new Date() },
-      })
-      .returning({ id: records.id });
-    if (!newRecord) {
-      throw new Error('Failed to create record');
-    }
-
-    await db
-      .update(twitterTweets)
-      .set({ recordId: newRecord.id })
-      .where(eq(twitterTweets.id, tweet.id));
-
-    updatedTweetIds.push(tweet.id);
-    recordMap.set(tweet.id, newRecord.id);
-
-    // Link the tweet creator via recordCreators.
-    if (tweet.user.recordId) {
-      await linkRecords(newRecord.id, tweet.user.recordId, 'created_by', db, { log: false });
-      logger.info(
-        `Created record ${newRecord.id} for tweet ${tweet.text?.slice(0, 20)} (${tweet.id}); created_by -> ${tweet.user.recordId}`
-      );
-    } else {
-      logger.info(
-        `Created record ${newRecord.id} for tweet ${tweet.text?.slice(0, 20)} (${tweet.id})`
-      );
-    }
-
-    // Link the tweet media via recordMedia.
-    for (const mediaItem of tweet.media) {
-      if (mediaItem.mediaId) {
-        logger.info(`Linking media ${mediaItem.mediaId} to record ${newRecord.id}`);
-        await db
-          .update(media)
-          .set({ recordId: newRecord.id })
-          .where(eq(media.id, mediaItem.mediaId));
+      // Insert the record with parentId set to null (to be updated later if this is a quote).
+      const [newRecord] = await db
+        .insert(records)
+        .values(record)
+        .onConflictDoUpdate({
+          target: records.id,
+          set: { recordUpdatedAt: new Date() },
+        })
+        .returning({ id: records.id });
+      if (!newRecord) {
+        throw new Error('Failed to create record');
       }
-    }
-  }
+
+      await db
+        .update(twitterTweets)
+        .set({ recordId: newRecord.id })
+        .where(eq(twitterTweets.id, tweet.id));
+
+      updatedTweetIds.push(tweet.id);
+      recordMap.set(tweet.id, newRecord.id);
+
+      // Link the tweet creator via recordCreators.
+      if (tweet.user.recordId) {
+        await linkRecords(newRecord.id, tweet.user.recordId, 'created_by', db, { log: false });
+        logger.info(
+          `Created record ${newRecord.id} for tweet ${tweet.text?.slice(0, 20)} (${tweet.id}); created_by -> ${tweet.user.recordId}`
+        );
+      } else {
+        logger.info(
+          `Created record ${newRecord.id} for tweet ${tweet.text?.slice(0, 20)} (${tweet.id})`
+        );
+      }
+
+      // Link the tweet media via recordMedia.
+      for (const mediaItem of tweet.media) {
+        if (mediaItem.mediaId) {
+          logger.info(`Linking media ${mediaItem.mediaId} to record ${newRecord.id}`);
+          await db
+            .update(media)
+            .set({ recordId: newRecord.id })
+            .where(eq(media.id, mediaItem.mediaId));
+        }
+      }
+    },
+  });
+  throwPoolFailures(tweetResults, 'Twitter tweet→record mapping', tweets.length);
 
   // Update relationships for tweets that quote or reply to another tweet.
   if (updatedTweetIds.length > 0) {
@@ -248,19 +263,28 @@ export async function linkQuotedTweets(tweetIds: string[]) {
 
   logger.info(`Found ${tweetsWithQuotes.length} tweets with quotes to link`);
 
+  const links: LinkInsert[] = [];
   for (const tweet of tweetsWithQuotes) {
     // The quoted tweet should already have been processed.
-    const quotedTweet = tweet.quotedTweet!;
-    if (!tweet.recordId || !quotedTweet.recordId) {
+    const quotedTweet = tweet.quotedTweet;
+    if (!tweet.recordId || !quotedTweet?.recordId) {
       logger.warn(`Quoted tweet ${tweet.id} not linked to record`);
       continue;
     }
 
     // Link the tweet record to the quoted tweet record.
-    await linkRecords(tweet.recordId, quotedTweet.recordId, 'quotes', db, { log: false });
+    links.push({
+      sourceId: tweet.recordId,
+      targetId: quotedTweet.recordId,
+      predicate: 'quotes',
+    });
     logger.info(
       `Linked quote: tweet record ${tweet.recordId} quotes -> ${quotedTweet.recordId} (${tweet.id} -> ${quotedTweet.id})`
     );
+  }
+
+  if (links.length > 0) {
+    await bulkInsertLinks(links, db);
   }
 
   logger.complete(`Linked ${tweetsWithQuotes.length} quoted tweets`);
@@ -293,6 +317,7 @@ export async function linkRepliedToTweets(tweetIds: string[]) {
 
   logger.info(`Found ${tweetsWithReplies.length} tweets with replies to link`);
 
+  const links: LinkInsert[] = [];
   for (const tweet of tweetsWithReplies) {
     const parentTweet = tweet.inReplyToTweet;
     if (!parentTweet) {
@@ -306,10 +331,18 @@ export async function linkRepliedToTweets(tweetIds: string[]) {
     }
 
     // Link the reply record to the parent tweet record via responds_to
-    await linkRecords(tweet.recordId, parentTweet.recordId, 'responds_to', db, { log: false });
+    links.push({
+      sourceId: tweet.recordId,
+      targetId: parentTweet.recordId,
+      predicate: 'responds_to',
+    });
     logger.info(
       `Linked reply: tweet record ${tweet.recordId} responds_to -> ${parentTweet.recordId} (${tweet.id} -> ${parentTweet.id})`
     );
+  }
+
+  if (links.length > 0) {
+    await bulkInsertLinks(links, db);
   }
 
   logger.complete(`Linked ${tweetsWithReplies.length} reply tweets`);
@@ -385,86 +418,76 @@ export async function createMediaFromTweets() {
 
   logger.info(`Found ${mediaWithTweets.length} Twitter media items to process`);
 
-  // Process media in batches for parallelization
-  const BATCH_SIZE = 3; // Process 3 media items at a time
   let processed = 0;
+  await runConcurrentPool({
+    items: mediaWithTweets,
+    concurrency: 3,
+    async worker(item) {
+      try {
+        logger.info(
+          `[${++processed}/${mediaWithTweets.length}] Processing media: ${item.mediaUrl}`
+        );
 
-  for (let i = 0; i < mediaWithTweets.length; i += BATCH_SIZE) {
-    const batch = mediaWithTweets.slice(i, i + BATCH_SIZE);
-
-    logger.info(
-      `Processing batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(mediaWithTweets.length / BATCH_SIZE)} (${batch.length} items)`
-    );
-
-    // Process batch in parallel
-    await Promise.all(
-      batch.map(async (item) => {
-        try {
-          logger.info(
-            `[${++processed}/${mediaWithTweets.length}] Processing media: ${item.mediaUrl}`
+        const mediaItem = await mapTwitterMediaToMedia(item);
+        if (!mediaItem) {
+          logger.error(
+            `Failed to create media for tweet ${item.tweetUrl}: ${item.mediaUrl}, deleting source media`
           );
 
-          const mediaItem = await mapTwitterMediaToMedia(item);
-          if (!mediaItem) {
-            logger.error(
-              `Failed to create media for tweet ${item.tweetUrl}: ${item.mediaUrl}, deleting source media`
-            );
-
-            await db
-              .update(twitterMedia)
-              .set({ mediaId: null, deletedAt: new Date() })
-              .where(eq(twitterMedia.id, item.id));
-
-            return;
-          }
-
-          logger.info(
-            `[${processed}/${mediaWithTweets.length}] Creating media record for ${mediaItem.url}`
-          );
-
-          const [newMedia] = await db
-            .insert(media)
-            .values(mediaItem)
-            .onConflictDoUpdate({
-              target: [media.url, media.recordId],
-              set: {
-                recordUpdatedAt: new Date(),
-              },
-            })
-            .returning({ id: media.id });
-
-          if (!newMedia) {
-            throw new Error('Failed to create media');
-          }
-
-          logger.info(
-            `[${processed}/${mediaWithTweets.length}] ✓ Created media ${newMedia.id} for ${mediaItem.url}`
-          );
-
-          await db
-            .update(twitterMedia)
-            .set({ mediaId: newMedia.id, mediaUrl: mediaItem.url })
-            .where(eq(twitterMedia.id, item.id));
-
-          if (item.tweet.recordId) {
-            logger.info(`Linking media ${newMedia.id} to record ${item.tweet.recordId}`);
-
-            await db
-              .update(media)
-              .set({ recordId: item.tweet.recordId })
-              .where(eq(media.id, newMedia.id));
-          }
-        } catch (error) {
-          logger.error(`Failed to process media ${item.mediaUrl}:`, error);
-          // Mark as deleted to skip in future runs
           await db
             .update(twitterMedia)
             .set({ mediaId: null, deletedAt: new Date() })
             .where(eq(twitterMedia.id, item.id));
+
+          return;
         }
-      })
-    );
-  }
+
+        logger.info(
+          `[${processed}/${mediaWithTweets.length}] Creating media record for ${mediaItem.url}`
+        );
+
+        const [newMedia] = await db
+          .insert(media)
+          .values(mediaItem)
+          .onConflictDoUpdate({
+            target: [media.url, media.recordId],
+            set: {
+              recordUpdatedAt: new Date(),
+            },
+          })
+          .returning({ id: media.id });
+
+        if (!newMedia) {
+          throw new Error('Failed to create media');
+        }
+
+        logger.info(
+          `[${processed}/${mediaWithTweets.length}] ✓ Created media ${newMedia.id} for ${mediaItem.url}`
+        );
+
+        await db
+          .update(twitterMedia)
+          .set({ mediaId: newMedia.id, mediaUrl: mediaItem.url })
+          .where(eq(twitterMedia.id, item.id));
+
+        if (item.tweet.recordId) {
+          logger.info(`Linking media ${newMedia.id} to record ${item.tweet.recordId}`);
+
+          await db
+            .update(media)
+            .set({ recordId: item.tweet.recordId })
+            .where(eq(media.id, newMedia.id));
+        }
+      } catch (error) {
+        logger.error(`Failed to process media ${item.mediaUrl}:`, error);
+        // Mark as deleted to skip in future runs
+        await db
+          .update(twitterMedia)
+          .set({ mediaId: null, deletedAt: new Date() })
+          .where(eq(twitterMedia.id, item.id));
+      }
+    },
+  });
 
   logger.complete(`Processed ${mediaWithTweets.length} Twitter media items`);
 }

--- a/src/server/integrations/twitter/sync.ts
+++ b/src/server/integrations/twitter/sync.ts
@@ -8,7 +8,6 @@ import {
 } from '@hozo';
 import { db } from '@/server/db/connections/postgres';
 import { runConcurrentPool } from '@/shared/lib/async-pool';
-import { conflictUpdateSet } from '../common/db-helpers';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -585,28 +584,24 @@ async function storeTweetData(
         `Users: total=${processedUsers.length} new=${newUsers} existing=${existingUserIds.size}`
       );
 
-      const userSetColumns = conflictUpdateSet(usersTable, [
-        'description',
-        'displayName',
-        'username',
-        'location',
-        'profileImageUrl',
-        'profileBannerUrl',
-        'url',
-        'externalUrl',
-        'contentCreatedAt',
-        'integrationRunId',
-      ]);
-      for (let i = 0; i < processedUsers.length; i += INSERT_CHUNK_SIZE) {
-        const chunk = processedUsers.slice(i, i + INSERT_CHUNK_SIZE);
+      let userIndex = 0;
+      for (const user of processedUsers) {
+        userIndex++;
+        const action = existingUserIds.has(user.id) ? 'update' : 'insert';
+        logger.info(
+          `User ${formatProgress(userIndex, processedUsers.length)} ${action} @${user.username} (${user.id})`
+        );
+
         await tx
           .insert(usersTable)
-          .values(chunk)
+          .values(user)
           .onConflictDoUpdate({
             target: [usersTable.id],
-            set: { ...userSetColumns, recordUpdatedAt: new Date() },
+            set: {
+              ...user,
+              recordUpdatedAt: new Date(),
+            },
           });
-        logger.info(`Users ${formatProgress(i + chunk.length, processedUsers.length)} upserted`);
       }
 
       // 2. Insert Tweets (already topologically sorted so dependencies come first)
@@ -616,28 +611,23 @@ async function storeTweetData(
         `Tweets: total=${processedTweets.length} new=${newTweetsCount} existing=${existingTweetIds.size}`
       );
 
-      const tweetSetColumns = conflictUpdateSet(tweetsTable, [
-        'userId',
-        'text',
-        'quotedTweetId',
-        'inReplyToTweetId',
-        'conversationId',
-        'contentCreatedAt',
-        'integrationRunId',
-      ]);
-      // Chunks are processed in order (not concurrently): tweets are topologically sorted so
-      // parent/quoted tweets precede replies, and a referenced tweet must already be in an
-      // earlier-or-same chunk when its dependent is inserted.
-      for (let i = 0; i < processedTweets.length; i += INSERT_CHUNK_SIZE) {
-        const chunk = processedTweets.slice(i, i + INSERT_CHUNK_SIZE);
+      let tweetIndex = 0;
+      for (const tweet of processedTweets) {
+        tweetIndex++;
+        const action = existingTweetIds.has(tweet.id) ? 'update' : 'insert';
+        const tweetType = tweet.quotedTweetId ? 'quote' : 'tweet';
+        const suffix = tweet.quotedTweetId ? ` -> ${tweet.quotedTweetId}` : '';
+        logger.info(
+          `Tweet ${formatProgress(tweetIndex, processedTweets.length)} ${action} ${tweetType} (${tweet.id}${suffix})`
+        );
+
         await tx
           .insert(tweetsTable)
-          .values(chunk)
+          .values(tweet)
           .onConflictDoUpdate({
             target: tweetsTable.id,
-            set: { ...tweetSetColumns, recordUpdatedAt: new Date() },
+            set: { ...tweet, recordUpdatedAt: new Date() },
           });
-        logger.info(`Tweets ${formatProgress(i + chunk.length, processedTweets.length)} upserted`);
       }
 
       // 3. Insert Media (new rows only; existing media is updated separately once its R2 upload completes)

--- a/src/server/integrations/twitter/sync.ts
+++ b/src/server/integrations/twitter/sync.ts
@@ -7,6 +7,8 @@ import {
   type TwitterUserInsert,
 } from '@hozo';
 import { db } from '@/server/db/connections/postgres';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
+import { conflictUpdateSet } from '../common/db-helpers';
 import { createDebugContext } from '../common/debug-output';
 import { createIntegrationLogger } from '../common/logging';
 import { runIntegration } from '../common/run-integration';
@@ -222,6 +224,7 @@ async function fetchMissingParentTweets(
   // Collect reply parent IDs that need fetching
   const batchTweetIds = new Set(tweets.map((t) => t.rest_id));
   const parentIdsToFetch: string[] = [];
+  const parentIdsToFetchSet = new Set<string>();
 
   for (const tweet of tweets) {
     const replyToId = tweet.legacy.in_reply_to_status_id_str;
@@ -236,7 +239,8 @@ async function fetchMissingParentTweets(
       // Skip if already in current batch or known to exist in DB
       if (!batchTweetIds.has(replyToId) && !knownExistingIds.has(replyToId)) {
         // Avoid duplicates in the fetch list
-        if (!parentIdsToFetch.includes(replyToId)) {
+        if (!parentIdsToFetchSet.has(replyToId)) {
+          parentIdsToFetchSet.add(replyToId);
           parentIdsToFetch.push(replyToId);
         }
       }
@@ -251,50 +255,63 @@ async function fetchMissingParentTweets(
   logger.info(`Fetching ${parentIdsToFetch.length} parent tweets...`);
 
   const client = createTwitterClient({ timeoutMs: 30000 });
-  const parentTweets: TweetData[] = [];
-  const failedFetchIds: string[] = [];
 
-  for (let i = 0; i < parentIdsToFetch.length; i++) {
-    const parentId = parentIdsToFetch[i];
-    if (!parentId) {
-      continue;
-    }
-    try {
-      const result = await client.fetchTweetById(parentId);
+  type ParentFetchResult =
+    | { status: 'success'; tweet: TweetData }
+    | { status: 'failed'; parentId: string };
 
-      if (result.success) {
-        const parsed = TimelineItemSchema.safeParse(result.tweetResult);
-        if (parsed.success) {
-          const tweetResult = parsed.data;
+  const fetchResults = await runConcurrentPool({
+    items: parentIdsToFetch,
+    concurrency: 3,
+    onProgress: (completed, total) => {
+      logger.info(`Parent tweet fetch progress: ${completed}/${total}`);
+    },
+    async worker(parentId): Promise<ParentFetchResult> {
+      try {
+        const result = await client.fetchTweetById(parentId);
 
-          if (isTweetWithVisibilityResults(tweetResult)) {
-            logger.info(`Fetched parent tweet ${parentId}`);
-            parentTweets.push({ ...tweetResult.tweet, isQuoted: false });
-          } else if (isTweet(tweetResult)) {
-            logger.info(`Fetched parent tweet ${parentId}`);
-            parentTweets.push({ ...tweetResult, isQuoted: false });
-          } else {
+        if (result.success) {
+          const parsed = TimelineItemSchema.safeParse(result.tweetResult);
+          if (parsed.success) {
+            const tweetResult = parsed.data;
+
+            if (isTweetWithVisibilityResults(tweetResult)) {
+              logger.info(`Fetched parent tweet ${parentId}`);
+              return { status: 'success', tweet: { ...tweetResult.tweet, isQuoted: false } };
+            } else if (isTweet(tweetResult)) {
+              logger.info(`Fetched parent tweet ${parentId}`);
+              return { status: 'success', tweet: { ...tweetResult, isQuoted: false } };
+            }
             logger.warn(
               `Parent tweet ${parentId} is not a valid tweet type: ${tweetResult.__typename}`
             );
-            failedFetchIds.push(parentId);
+            return { status: 'failed', parentId };
           }
-        } else {
           logger.warn(`Failed to parse parent tweet ${parentId}: ${parsed.error.message}`);
-          failedFetchIds.push(parentId);
+          return { status: 'failed', parentId };
         }
-      } else {
         logger.warn(`Failed to fetch parent tweet ${parentId}: ${result.error}`);
-        failedFetchIds.push(parentId);
+        return { status: 'failed', parentId };
+      } catch (error) {
+        logger.error(`Error fetching parent tweet ${parentId}`, error);
+        return { status: 'failed', parentId };
       }
-    } catch (error) {
-      logger.error(`Error fetching parent tweet ${parentId}`, error);
-      failedFetchIds.push(parentId);
-    }
+    },
+  });
 
-    // Small delay between requests for rate limiting
-    await Bun.sleep(300);
-    logger.info(`Parent tweet fetch progress: ${i + 1}/${parentIdsToFetch.length}`);
+  const parentTweets: TweetData[] = [];
+  const failedFetchIds: string[] = [];
+  for (const result of fetchResults) {
+    if (!result.ok) {
+      // Workers always catch their own errors and return a result, so this shouldn't happen.
+      logger.error('Unexpected parent tweet fetch failure', result.error);
+      continue;
+    }
+    if (result.value.status === 'success') {
+      parentTweets.push(result.value.tweet);
+    } else {
+      failedFetchIds.push(result.value.parentId);
+    }
   }
 
   logger.info(`Fetched ${parentTweets.length} parent tweets, ${failedFetchIds.length} failed`);
@@ -489,6 +506,7 @@ async function storeTweetData(
   return db.transaction(
     async (tx) => {
       const CHUNK_SIZE = 1000;
+      const INSERT_CHUNK_SIZE = 500;
 
       const getExistingTwitterUserIds = async (ids: string[]): Promise<Set<string>> => {
         const existing = new Set<string>();
@@ -567,24 +585,28 @@ async function storeTweetData(
         `Users: total=${processedUsers.length} new=${newUsers} existing=${existingUserIds.size}`
       );
 
-      let userIndex = 0;
-      for (const user of processedUsers) {
-        userIndex++;
-        const action = existingUserIds.has(user.id) ? 'update' : 'insert';
-        logger.info(
-          `User ${formatProgress(userIndex, processedUsers.length)} ${action} @${user.username} (${user.id})`
-        );
-
+      const userSetColumns = conflictUpdateSet(usersTable, [
+        'description',
+        'displayName',
+        'username',
+        'location',
+        'profileImageUrl',
+        'profileBannerUrl',
+        'url',
+        'externalUrl',
+        'contentCreatedAt',
+        'integrationRunId',
+      ]);
+      for (let i = 0; i < processedUsers.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = processedUsers.slice(i, i + INSERT_CHUNK_SIZE);
         await tx
           .insert(usersTable)
-          .values(user)
+          .values(chunk)
           .onConflictDoUpdate({
             target: [usersTable.id],
-            set: {
-              ...user,
-              recordUpdatedAt: new Date(),
-            },
+            set: { ...userSetColumns, recordUpdatedAt: new Date() },
           });
+        logger.info(`Users ${formatProgress(i + chunk.length, processedUsers.length)} upserted`);
       }
 
       // 2. Insert Tweets (already topologically sorted so dependencies come first)
@@ -594,43 +616,41 @@ async function storeTweetData(
         `Tweets: total=${processedTweets.length} new=${newTweetsCount} existing=${existingTweetIds.size}`
       );
 
-      let tweetIndex = 0;
-      for (const tweet of processedTweets) {
-        tweetIndex++;
-        const action = existingTweetIds.has(tweet.id) ? 'update' : 'insert';
-        const tweetType = tweet.quotedTweetId ? 'quote' : 'tweet';
-        const suffix = tweet.quotedTweetId ? ` -> ${tweet.quotedTweetId}` : '';
-        logger.info(
-          `Tweet ${formatProgress(tweetIndex, processedTweets.length)} ${action} ${tweetType} (${tweet.id}${suffix})`
-        );
-
+      const tweetSetColumns = conflictUpdateSet(tweetsTable, [
+        'userId',
+        'text',
+        'quotedTweetId',
+        'inReplyToTweetId',
+        'conversationId',
+        'contentCreatedAt',
+        'integrationRunId',
+      ]);
+      // Chunks are processed in order (not concurrently): tweets are topologically sorted so
+      // parent/quoted tweets precede replies, and a referenced tweet must already be in an
+      // earlier-or-same chunk when its dependent is inserted.
+      for (let i = 0; i < processedTweets.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = processedTweets.slice(i, i + INSERT_CHUNK_SIZE);
         await tx
           .insert(tweetsTable)
-          .values(tweet)
+          .values(chunk)
           .onConflictDoUpdate({
             target: tweetsTable.id,
-            set: { ...tweet, recordUpdatedAt: new Date() },
+            set: { ...tweetSetColumns, recordUpdatedAt: new Date() },
           });
+        logger.info(`Tweets ${formatProgress(i + chunk.length, processedTweets.length)} upserted`);
       }
 
-      // 3. Insert Media
+      // 3. Insert Media (new rows only; existing media is updated separately once its R2 upload completes)
       const existingMediaIds = await getExistingMediaIds(processedMedia.map((m) => m.id));
-      const newMediaItems = processedMedia.length - existingMediaIds.size;
+      const newMediaRows = processedMedia.filter((m) => !existingMediaIds.has(m.id));
       logger.info(
-        `Media: total=${processedMedia.length} new=${newMediaItems} existing=${existingMediaIds.size}`
+        `Media: total=${processedMedia.length} new=${newMediaRows.length} existing=${existingMediaIds.size}`
       );
 
-      let mediaInsertIndex = 0;
-      for (const mediaItem of processedMedia) {
-        if (existingMediaIds.has(mediaItem.id)) {
-          continue;
-        }
-
-        mediaInsertIndex++;
-        logger.info(
-          `Media ${formatProgress(mediaInsertIndex, newMediaItems)} insert (${mediaItem.id}) ${mediaItem.type} ${mediaItem.tweetUrl}`
-        );
-        await tx.insert(mediaTable).values(mediaItem).onConflictDoNothing();
+      for (let i = 0; i < newMediaRows.length; i += INSERT_CHUNK_SIZE) {
+        const chunk = newMediaRows.slice(i, i + INSERT_CHUNK_SIZE);
+        await tx.insert(mediaTable).values(chunk).onConflictDoNothing();
+        logger.info(`Media ${formatProgress(i + chunk.length, newMediaRows.length)} inserted`);
       }
 
       logger.info(

--- a/src/server/services/embed-records.ts
+++ b/src/server/services/embed-records.ts
@@ -2,6 +2,7 @@ import { records, RunTypeSchema } from '@hozo';
 import { eq, inArray } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { createEmbeddings } from '@/server/lib/create-embedding';
+import { runConcurrentPool } from '@/shared/lib/async-pool';
 import { createRecordEmbeddingText, getRecordTitle } from '@/shared/lib/embedding';
 import type { FullRecord } from '@/shared/types/domain';
 import { createIntegrationLogger } from '../integrations/common/logging';
@@ -11,6 +12,9 @@ const logger = createIntegrationLogger('services', 'embed-records');
 
 /** Records embedded (and written back) per OpenAI request. */
 const EMBED_BATCH_SIZE = 64;
+
+/** Number of embedding batches processed concurrently. */
+const EMBED_CONCURRENCY = 4;
 
 export interface EmbedRecordResult {
   recordId: number;
@@ -71,46 +75,53 @@ export async function embedRecordsByIds(recordIds: number[]): Promise<EmbedRecor
     pending.push({ recordId, record, text });
   }
 
+  const batches: { start: number; items: typeof pending }[] = [];
   for (let start = 0; start < pending.length; start += EMBED_BATCH_SIZE) {
-    const batch = pending.slice(start, start + EMBED_BATCH_SIZE);
-
-    try {
-      const embeddings = await createEmbeddings(batch.map((item) => item.text));
-
-      await Promise.all(
-        batch.map(async (item, index) => {
-          const embedding = embeddings[index];
-          if (!embedding) {
-            resultMap.set(item.recordId, {
-              recordId: item.recordId,
-              success: false,
-              error: 'Missing embedding in batch response',
-            });
-            return;
-          }
-
-          await db
-            .update(records)
-            .set({ textEmbedding: embedding })
-            .where(eq(records.id, item.recordId));
-          resultMap.set(item.recordId, { recordId: item.recordId, success: true });
-        })
-      );
-
-      const last = batch.at(-1);
-      if (batch.length === 1 && last) {
-        logger.info(`Embedded record ${last.recordId}: ${getRecordTitle(last.record, 80)}`);
-      } else {
-        logger.info(`Embedded records ${start + 1}–${start + batch.length} of ${pending.length}`);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Failed to embed batch of ${batch.length} record(s): ${message}`);
-      for (const item of batch) {
-        resultMap.set(item.recordId, { recordId: item.recordId, success: false, error: message });
-      }
-    }
+    batches.push({ start, items: pending.slice(start, start + EMBED_BATCH_SIZE) });
   }
+
+  await runConcurrentPool({
+    items: batches,
+    concurrency: EMBED_CONCURRENCY,
+    async worker({ start, items: batch }) {
+      try {
+        const embeddings = await createEmbeddings(batch.map((item) => item.text));
+
+        await Promise.all(
+          batch.map(async (item, index) => {
+            const embedding = embeddings[index];
+            if (!embedding) {
+              resultMap.set(item.recordId, {
+                recordId: item.recordId,
+                success: false,
+                error: 'Missing embedding in batch response',
+              });
+              return;
+            }
+
+            await db
+              .update(records)
+              .set({ textEmbedding: embedding })
+              .where(eq(records.id, item.recordId));
+            resultMap.set(item.recordId, { recordId: item.recordId, success: true });
+          })
+        );
+
+        const last = batch.at(-1);
+        if (batch.length === 1 && last) {
+          logger.info(`Embedded record ${last.recordId}: ${getRecordTitle(last.record, 80)}`);
+        } else {
+          logger.info(`Embedded records ${start + 1}–${start + batch.length} of ${pending.length}`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`Failed to embed batch of ${batch.length} record(s): ${message}`);
+        for (const item of batch) {
+          resultMap.set(item.recordId, { recordId: item.recordId, success: false, error: message });
+        }
+      }
+    },
+  });
 
   const results = uniqueIds.map(
     (recordId) => resultMap.get(recordId) ?? { recordId, success: false, error: 'Unknown error' }


### PR DESCRIPTION
Sync runs spend most of their wall time waiting. The daily sync runs its six integrations one after another, and inside them nearly every loop is either fully sequential or paced by a fixed sleep guarding a rate limit that's nowhere near exceeded — the GitHub sync slept a full second per item even when the item made no API call at all (a commit already in the database, a plain Postgres write). GitHub's actual budget is 5,000 core requests per hour; an incremental sync uses a few dozen.

The daily sync now runs all integrations concurrently. To keep the streamed output readable, each integration's log lines are buffered (`withBufferedLogs`, an `AsyncLocalStorage` scope threaded through the shared logger) and flushed as one contiguous block the moment that integration finishes, so concurrent runs never interleave. Scopes nest, which the GitHub, browser, agent-history, and readwise/raindrop sub-steps use for their own internal concurrency.

The GitHub sync gets the deepest rework:

- Stars and commits are independent and now run as separate, concurrent integration runs; commit-driven repository upserts no longer touch `starredAt`, so the two can't clobber each other.
- Fixed sleeps are replaced by `@octokit/plugin-throttling`, which retries on the server-indicated delay when a primary or secondary limit is actually hit.
- Commit processing runs through a bounded pool with one bulk existence check per page, memoized repository fetches (a push lands many commits in one repo), and batched file-change inserts; stars fetch at the API's maximum page size and persist through the pool instead of sleeping a second per row.

The same treatment applies across the other integrations: sequential per-row loops in raindrop, readwise, twitter, airtable, adobe, feedbin, browser history, and the embedding service now run through the existing `runConcurrentPool`, issuing the same statements as before. Upsert shapes are untouched — each row still writes via its original `.values(row)` spread — so no column lists to drift out of sync with the processors. Readwise documents insert level-by-level so parents still land before children; twitter tweets keep their topological order.

Fixes a readwise linking gap along the way: adding a tag in Readwise to an already-synced document arrives as a document update, which neither linking path covered — the tag side only processes new tags and the document side only processed unmapped documents. The document-side linking now also refreshes author and tag links for documents updated in the current run (link upserts make relinking a no-op). The ~30 historical links this had missed are backfilled directly.

Also: the browser-history hostname check no longer scans and groups the entire table to test one value, feedbin no longer loads every entry id in the database each run, airtable attachment processing fetches each extract from the API once instead of once per attachment, and a `publish:hozo` script rides along with the @aias/hozo 0.5.0 bump.