### PR TITLE
Rework the ELO seed script's ranking strategy and batch its writes

### DIFF
--- a/docs/prd-elo-ranking.md
+++ b/docs/prd-elo-ranking.md
@@ -182,17 +182,17 @@ Clean break: the `rating` column is dropped and all star-related UI, filters, an
 
 Current integrations map external signals to the 0–3 star scale. Under ELO:
 
-- **New records from integrations** get the default ELO (1200). External importance signals (Readwise stars, Raindrop important flag, Airtable michelin stars, Adobe ratings) are mapped to seed ELOs using the same star→ELO table from the migration.
+- **New records from integrations** get the default ELO (1200). External importance signals (Readwise stars, Raindrop important flag, Airtable michelin stars, Adobe ratings) are mapped to seed ELOs via a fixed signal→ELO table (1000/1200/1400/1600 for 0–3 stars).
 - **ELO is always user-sovereign.** Integration re-syncs never overwrite ELO scores, regardless of whether the record has matchup history. Once created, ELO is controlled exclusively through matchups.
 
 ## Implementation Phases
 
 ### Phase 1: Schema + migration
 
-- [ ] Add `eloScore` and `eloMatchups` columns to `records`
-- [ ] Create `elo_matchups` table
-- [ ] Backfill `eloScore` from existing `rating` values using the seed table
-- [ ] Set `eloMatchups` to 3 for all seeded records
+- [x] Add `eloScore` column to `records`
+- [ ] Add `eloMatchups` counter column to `records`
+- [x] Create `elo_matchups` table
+- [x] Seed `eloScore` from record richness signals (`src/server/db/seed-elo.ts`)
 
 ### Phase 2: ELO calculation + tRPC endpoints
 
@@ -229,16 +229,9 @@ Current integrations map external signals to the 0–3 star scale. Under ELO:
 - [ ] Drop `rating` column
 - [ ] Remove any remaining star references from integrations/CLI
 
-### Seed Table
+### Seeding
 
-| Stars | Initial ELO | Initial eloMatchups |
-| ----- | ----------- | ------------------- |
-| 0     | 1000        | 3                   |
-| 1     | 1200        | 3                   |
-| 2     | 1400        | 3                   |
-| 3     | 1600        | 3                   |
-
-The spread (200 points per star) is wide enough to be meaningful but narrow enough that a few matchups can overturn a bad seed. The phantom matchup count of 3 means seeded records start with K=32 but aren't quite as volatile as truly fresh records.
+Initial scores come from a richness heuristic over existing metadata rather than the star rating alone (`src/server/db/seed-elo.ts`). Each record's relevance is `(rating + curation boosts) × sqrt(weighted signal sum)` over links, media, notes, summary, and content. Within each type, percentile rank is mapped through an inverse normal CDF centered on the 1200 default (sd 150), so seeds follow the bell-shaped distribution matchup play converges to and new records enter at the median. Seeded records carry no matchup history: K=32 lets real comparisons quickly overturn a bad seed.
 
 ## Decisions
 
@@ -255,7 +248,7 @@ The spread (200 points per star) is wide enough to be meaningful but narrow enou
 - **Cycles:** No detection or prevention. ELO handles them naturally.
 - **Decay:** No score decay. Matchup selection biases toward records that haven't been compared recently.
 - **Integration sovereignty:** ELO is always user-sovereign. Re-syncs never overwrite, even for zero-matchup records.
-- **Seeding:** Stars→ELO via migration table. `eloMatchups` set to 3 for seeded records.
+- **Seeding:** Per-type richness percentile mapped through an inverse normal CDF centered on 1200 (sd 150). No phantom matchup count — seeds stay volatile (K=32) until real comparisons accumulate.
 - **New records:** No ranking nudge on creation. Records sit at 1200 until organically encountered.
 - **API consolidation:** Single `getMatchup` endpoint with optional `focusRecordId` param instead of separate random/settle queries.
 - **Matchup history:** Not surfaced in UI. Fire-and-forget; only scores matter.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/server/db/seed-elo.ts
+++ b/src/server/db/seed-elo.ts
@@ -5,33 +5,36 @@
  * Computes initial ELO scores for all records based on richness
  * signals: rating, link topology, media, content completeness.
  *
- * Scores are computed per record type (entity/concept/artifact)
- * using percentile-based mapping to the ELO range [900–1700].
+ * Scores are computed per record type (entity/concept/artifact):
+ * each record's within-type percentile is mapped through an inverse
+ * normal CDF centered on the 1200 default (sd 150), so seeds follow
+ * the bell-shaped distribution matchup play converges to and new
+ * records enter at the median.
  *
- * Idempotent — safe to run multiple times. Overwrites eloScore
- * for all records (since no matchup history exists yet).
+ * Refuses to run once matchup history exists — ELO is user-sovereign
+ * after ranking begins. Pass --force to overwrite anyway.
  *
  * Usage:
  *   NODE_ENV=development bun src/server/db/seed-elo.ts
  *   NODE_ENV=development bun src/server/db/seed-elo.ts --dry-run
  */
 
-import { records } from '@hozo';
-import { eq, sql } from 'drizzle-orm';
+import { eloMatchups, type RecordType } from '@hozo';
+import { sql } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
 import { createIntegrationLogger } from '../integrations/common/logging';
 
 const logger = createIntegrationLogger('db', 'seed-elo');
 
-const ELO_MIN = 900;
-const ELO_MAX = 1700;
+const ELO_MEAN = 1200;
+const ELO_SD = 150;
 
 // ── Data fetching ──────────────────────────────────────────────
 
 interface RecordSignals {
   id: number;
   title: string | null;
-  type: string;
+  type: RecordType;
   rating: number;
   isCurated: boolean;
   hasNotes: boolean;
@@ -46,13 +49,14 @@ interface RecordSignals {
 
 /**
  * Fetch all records with their richness signals in a single query.
- * Uses lateral subqueries for link/media counts to avoid N+1.
+ * Link counts for both directions come from a single pass over links —
+ * direction is an artifact of entry order, not importance.
  */
 async function fetchRecordSignals(): Promise<RecordSignals[]> {
   const rows = await db.execute<{
     id: number;
     title: string | null;
-    type: string;
+    type: RecordType;
     rating: number;
     is_curated: boolean;
     has_notes: boolean;
@@ -75,27 +79,24 @@ async function fetchRecordSignals(): Promise<RecordSignals[]> {
       r.summary IS NOT NULL AND r.summary != '' AS has_summary,
       r.content IS NOT NULL AND r.content != '' AS has_content,
       r.media_caption IS NOT NULL AND r.media_caption != '' AS has_media_caption,
-      -- Containment links (both directions): structural hierarchy
-      COALESCE(cl.cnt, 0) AS containment_links,
-      -- All other links (both directions), excluding format (noise, not signal)
-      COALESCE(ol.cnt, 0) AS other_links,
-      -- Media attachments
+      COALESCE(l.containment_cnt, 0) AS containment_links,
+      COALESCE(l.other_cnt, 0) AS other_links,
       COALESCE(m.cnt, 0) AS media_count
     FROM records r
     LEFT JOIN (
-      SELECT rid, COUNT(*) AS cnt FROM (
-        SELECT source_id AS rid FROM links WHERE predicate IN ('contained_by', 'quotes')
+      SELECT
+        rid,
+        -- Containment links: structural hierarchy
+        COUNT(*) FILTER (WHERE predicate IN ('contained_by', 'quotes')) AS containment_cnt,
+        -- All other links, excluding format (noise, not signal)
+        COUNT(*) FILTER (WHERE predicate NOT IN ('contained_by', 'quotes', 'has_format')) AS other_cnt
+      FROM (
+        SELECT source_id AS rid, predicate FROM links
         UNION ALL
-        SELECT target_id AS rid FROM links WHERE predicate IN ('contained_by', 'quotes')
-      ) t GROUP BY rid
-    ) cl ON cl.rid = r.id
-    LEFT JOIN (
-      SELECT rid, COUNT(*) AS cnt FROM (
-        SELECT source_id AS rid FROM links WHERE predicate NOT IN ('contained_by', 'quotes', 'has_format')
-        UNION ALL
-        SELECT target_id AS rid FROM links WHERE predicate NOT IN ('contained_by', 'quotes', 'has_format')
-      ) t GROUP BY rid
-    ) ol ON ol.rid = r.id
+        SELECT target_id AS rid, predicate FROM links
+      ) t
+      GROUP BY rid
+    ) l ON l.rid = r.id
     LEFT JOIN (
       SELECT record_id AS rid, COUNT(*) AS cnt
       FROM media WHERE record_id IS NOT NULL
@@ -131,15 +132,12 @@ async function fetchRecordSignals(): Promise<RecordSignals[]> {
  * The multiplier (rating + boosts) ensures explicit curation
  * carries the most weight. The sqrt-dampened sum rewards breadth
  * of metadata without letting any single signal dominate.
- *
- * All link counts are bidirectional — direction is an artifact
- * of entry order, not importance.
  */
 function computeRelevance(s: RecordSignals): number {
   const multiplier = s.rating + 1 + (s.isCurated ? 1 : 0);
 
   const richness =
-    s.rating +
+    s.rating + // also in the multiplier — keeps rated-but-otherwise-empty records off the floor
     s.containmentLinks + // structural hierarchy (parent/child, quotes)
     s.otherLinks * 2 + // graph centrality (refs, tags, associations, creation)
     s.mediaCount * 2 + // visual richness
@@ -149,54 +147,90 @@ function computeRelevance(s: RecordSignals): number {
     (s.hasSummary ? 3 : 0) + // has summary
     (s.hasContent ? 4 : 0); // has substantial content
 
+  // Ratings can be -1 in legacy rows (below the insert schema's 0 floor),
+  // which zeroes the multiplier and can drive richness negative.
   return multiplier * Math.sqrt(Math.max(richness, 0));
 }
 
 // ── ELO mapping ────────────────────────────────────────────────
 
 interface ScoredRecord {
-  id: number;
-  type: string;
+  signal: RecordSignals;
   relevance: number;
   elo: number;
 }
 
 /**
- * Map relevance scores to ELO using percentile ranking within each type.
+ * Inverse standard normal CDF (Acklam's rational approximation,
+ * |ε| < 1.2e-9). Defined on the open interval (0, 1).
+ */
+function probit(p: number): number {
+  const pLow = 0.02425;
+  if (p < pLow || p > 1 - pLow) {
+    const c1 = -7.784894002430293e-3;
+    const c2 = -3.223964580411365e-1;
+    const c3 = -2.400758277161838;
+    const c4 = -2.549732539343734;
+    const c5 = 4.374664141464968;
+    const c6 = 2.938163982698783;
+    const d1 = 7.784695709041462e-3;
+    const d2 = 3.224671290700398e-1;
+    const d3 = 2.445134137142996;
+    const d4 = 3.754408661907416;
+    const q = Math.sqrt(-2 * Math.log(Math.min(p, 1 - p)));
+    const z =
+      (((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6) /
+      ((((d1 * q + d2) * q + d3) * q + d4) * q + 1);
+    return p < pLow ? z : -z;
+  }
+  const a1 = -3.969683028665376e1;
+  const a2 = 2.209460984245205e2;
+  const a3 = -2.759285104469687e2;
+  const a4 = 1.38357751867269e2;
+  const a5 = -3.066479806614716e1;
+  const a6 = 2.506628277459239;
+  const b1 = -5.447609879822406e1;
+  const b2 = 1.615858368580409e2;
+  const b3 = -1.556989798598866e2;
+  const b4 = 6.680131188771972e1;
+  const b5 = -1.328068155288572e1;
+  const q = p - 0.5;
+  const r = q * q;
+  return (
+    ((((((a1 * r + a2) * r + a3) * r + a4) * r + a5) * r + a6) * q) /
+    (((((b1 * r + b2) * r + b3) * r + b4) * r + b5) * r + 1)
+  );
+}
+
+/**
+ * Map relevance scores to ELO within each type: percentile rank
+ * through the inverse normal CDF, centered on the 1200 default.
  * Ties share the same percentile (average rank method).
  */
 function mapToElo(signalsList: RecordSignals[]): ScoredRecord[] {
-  const scored = signalsList.map((s) => ({
-    id: s.id,
-    type: s.type,
-    relevance: computeRelevance(s),
+  const scored: ScoredRecord[] = signalsList.map((signal) => ({
+    signal,
+    relevance: computeRelevance(signal),
     elo: 0,
   }));
 
-  // Group by type and assign ELO via percentile
-  const byType = Map.groupBy(scored, (r) => r.type);
+  const byType = Map.groupBy(scored, (r) => r.signal.type);
 
   for (const [type, group] of byType) {
-    if (!group || group.length === 0) continue;
+    const tiers = [...Map.groupBy(group, (r) => r.relevance)].sort(([a], [b]) => a - b);
 
-    if (group.length === 1) {
-      group[0]!.elo = Math.round((ELO_MIN + ELO_MAX) / 2);
-      continue;
+    let rank = 0;
+    for (const [, tied] of tiers) {
+      const midRank = rank + (tied.length - 1) / 2;
+      const percentile = (midRank + 0.5) / group.length;
+      const elo = Math.round(ELO_MEAN + ELO_SD * probit(percentile));
+      for (const r of tied) r.elo = elo;
+      rank += tied.length;
     }
 
-    // Sort by relevance ascending
-    group.sort((a, b) => a.relevance - b.relevance);
-
-    // Assign percentile rank (0 to 1)
-    for (let i = 0; i < group.length; i++) {
-      const percentile = i / (group.length - 1);
-      group[i]!.elo = Math.round(ELO_MIN + percentile * (ELO_MAX - ELO_MIN));
-    }
-
-    const first = group[0]!;
-    const last = group[group.length - 1]!;
+    const relevances = tiers.map(([relevance]) => relevance);
     logger.info(
-      `${type}: ${group.length} records, relevance range [${first.relevance.toFixed(1)}–${last.relevance.toFixed(1)}]`
+      `${type}: ${group.length} records, ${tiers.length} distinct relevance values in [${Math.min(...relevances).toFixed(1)}–${Math.max(...relevances).toFixed(1)}]`
     );
   }
 
@@ -205,52 +239,45 @@ function mapToElo(signalsList: RecordSignals[]): ScoredRecord[] {
 
 // ── Summary reporting ──────────────────────────────────────────
 
-function printSummary(scored: ScoredRecord[], signals: RecordSignals[]) {
-  const byType = Map.groupBy(scored, (r) => r.type);
-  const signalsById = new Map(signals.map((s) => [s.id, s]));
+function printSummary(scored: ScoredRecord[]) {
+  const byType = Map.groupBy(scored, (r) => r.signal.type);
 
   for (const [type, group] of byType) {
-    if (!group) continue;
-
     const sorted = [...group].sort((a, b) => b.elo - a.elo);
 
     // Distribution buckets
-    const buckets = new Map<string, number>();
+    const buckets = new Map<number, number>();
     for (const r of sorted) {
-      const bucket = `${Math.floor(r.elo / 100) * 100}–${Math.floor(r.elo / 100) * 100 + 99}`;
-      buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+      const floor = Math.floor(r.elo / 100) * 100;
+      buckets.set(floor, (buckets.get(floor) ?? 0) + 1);
     }
 
     logger.info(`\n── ${type} (${sorted.length} records) ──`);
     logger.info('Distribution:');
-    for (const [bucket, count] of [...buckets].sort(([a], [b]) => a.localeCompare(b))) {
+    for (const [floor, count] of [...buckets].sort(([a], [b]) => a - b)) {
       logger.info(
-        `  ${bucket}: ${'█'.repeat(Math.ceil(count / Math.max(sorted.length / 40, 1)))} (${count})`
+        `  ${floor}–${floor + 99}: ${'█'.repeat(Math.ceil(count / Math.max(sorted.length / 40, 1)))} (${count})`
       );
     }
 
-    // Top 15
     logger.info('Top 15:');
     for (const r of sorted.slice(0, 15)) {
-      const s = signalsById.get(r.id);
-      const title = s?.title ?? '(untitled)';
-      const links = s ? s.containmentLinks + s.otherLinks : 0;
-      const flags = [s?.rating ? `★${s.rating}` : '', s?.isCurated ? 'curated' : '']
+      const s = r.signal;
+      const links = s.containmentLinks + s.otherLinks;
+      const flags = [s.rating ? `★${s.rating}` : '', s.isCurated ? 'curated' : '']
         .filter(Boolean)
         .join(' ');
       logger.info(
-        `  ${r.elo}  ${r.relevance.toFixed(1).padStart(6)}  ${String(links).padStart(4)} links  ${title}  ${flags}`
+        `  ${r.elo}  ${r.relevance.toFixed(1).padStart(6)}  ${String(links).padStart(4)} links  ${s.title ?? '(untitled)'}  ${flags}`
       );
     }
 
-    // Bottom 10
     logger.info('Bottom 10:');
     for (const r of sorted.slice(-10)) {
-      const s = signalsById.get(r.id);
-      const title = s?.title ?? '(untitled)';
-      const links = s ? s.containmentLinks + s.otherLinks : 0;
+      const s = r.signal;
+      const links = s.containmentLinks + s.otherLinks;
       logger.info(
-        `  ${r.elo}  ${r.relevance.toFixed(1).padStart(6)}  ${String(links).padStart(4)} links  ${title}`
+        `  ${r.elo}  ${r.relevance.toFixed(1).padStart(6)}  ${String(links).padStart(4)} links  ${s.title ?? '(untitled)'}`
       );
     }
   }
@@ -258,37 +285,55 @@ function printSummary(scored: ScoredRecord[], signals: RecordSignals[]) {
 
 // ── Main ───────────────────────────────────────────────────────
 
-async function seedElo(dryRun: boolean): Promise<{ updated: number }> {
+async function seedElo(dryRun: boolean, force: boolean): Promise<{ updated: number }> {
+  const matchupCount = await db.$count(eloMatchups);
+  if (matchupCount > 0) {
+    if (!force) {
+      throw new Error(
+        `${matchupCount} matchups exist — ELO is user-sovereign once ranking begins. Pass --force to overwrite anyway.`
+      );
+    }
+    logger.warn(`Overwriting scores despite ${matchupCount} existing matchups (--force)`);
+  }
+
   logger.info('Fetching record signals...');
   const signals = await fetchRecordSignals();
   logger.info(`Found ${signals.length} records`);
 
   const scored = mapToElo(signals);
-  printSummary(scored, signals);
+  printSummary(scored);
 
   if (dryRun) {
     logger.info('\n🏁 Dry run — no changes written.');
     return { updated: 0 };
   }
 
-  // Batch update ELO scores
   logger.info('\nWriting ELO scores...');
-  let updated = 0;
-  for (const r of scored) {
-    await db.update(records).set({ eloScore: r.elo }).where(eq(records.id, r.id));
-    updated++;
-  }
-  logger.info(`Updated ${updated} records`);
+  // Array literals as single params — drizzle expands JS arrays into one
+  // placeholder per element, which overflows Postgres's parameter limit.
+  const ids = `{${scored.map((r) => r.signal.id).join(',')}}`;
+  const elos = `{${scored.map((r) => r.elo).join(',')}}`;
+  const updatedRows = await db.execute<{ id: number }>(sql`
+    UPDATE records r
+    SET elo_score = v.elo
+    FROM unnest(${ids}::int[], ${elos}::int[]) AS v(id, elo)
+    WHERE r.id = v.id AND r.elo_score IS DISTINCT FROM v.elo
+    RETURNING r.id
+  `);
+  logger.info(
+    `Updated ${updatedRows.length} records (${scored.length - updatedRows.length} unchanged)`
+  );
 
-  return { updated };
+  return { updated: updatedRows.length };
 }
 
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
+  const force = process.argv.includes('--force');
 
   try {
     logger.start(`=== ELO SEED ${dryRun ? '(DRY RUN) ' : ''}===`);
-    const result = await seedElo(dryRun);
+    const result = await seedElo(dryRun, force);
     logger.complete(`=== ELO SEED COMPLETED (${result.updated} updated) ===`);
     process.exit(0);
   } catch (error) {


### PR DESCRIPTION
The ELO seed script mapped within-type percentiles linearly onto [900–1700], which fought the rest of the system: the band centered on 1300 while new records enter at the default 1200, records with identical richness signals could land hundreds of points apart (percentiles were assigned per index, so tie order fell out of insertion order), and scores went out as one UPDATE per record.

- Maps each record's within-type percentile through an inverse normal CDF centered on the 1200 default (sd 150), so seeds follow the bell shape matchup play converges to and new records enter at the median
- Assigns tied relevance values a shared average-rank percentile, so records the heuristic can't distinguish get identical seeds
- Writes all scores in a single `UPDATE … FROM unnest(…)` and skips unchanged rows (arrays go over as Postgres array literals — drizzle expands a JS array param into one placeholder per element, which overflows the parameter limit at this row count)

A few smaller fixes: the script refuses to run once `elo_matchups` has rows, since ELO is user-sovereign after ranking begins (`--force` overrides); the links subquery counts both predicate groups in one pass instead of four scans; the summary histogram sorts buckets numerically instead of lexicographically; and the richness clamp stays because legacy rows can carry `rating = -1`, which would otherwise send a negative sum through `sqrt`.

Also reconciles the PRD's seeding section with this approach — the stars→ELO table survives only as the integration-mapping plan.

Dev and prod are both reseeded with this script: median 1200 per type, tails roughly 630–1810, with re-runs confirmed as no-ops.