### PR TITLE
Balance arena cards and rank linked records by Elo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/app/lib/hooks/elo-mutations.ts
+++ b/src/app/lib/hooks/elo-mutations.ts
@@ -1,8 +1,8 @@
 import { trpc } from '@/app/trpc';
 
 /**
- * Submit an ELO matchup (win/loss or draw). Both participants' cached records
- * are invalidated so displayed scores update; list order may have changed too.
+ * Submit an ELO matchup (win/loss or draw). Invalidate participant records and
+ * queries whose ordering depends on ELO scores.
  */
 export function useSubmitMatchup() {
   const utils = trpc.useUtils();
@@ -12,6 +12,7 @@ export function useSubmitMatchup() {
         void utils.records.get.invalidate({ id });
       }
       void utils.records.list.invalidate();
+      void utils.links.listForRecord.invalidate();
     },
   });
 }

--- a/src/app/routes/arena/-components/arena-session.tsx
+++ b/src/app/routes/arena/-components/arena-session.tsx
@@ -113,7 +113,7 @@ export function ArenaSession({ type, focus }: { type: RecordType; focus?: DbId }
       <styled.div
         css={{
           display: 'grid',
-          gridTemplateColumns: '[1fr auto 1fr]',
+          gridTemplateColumns: '[minmax(0, 1fr) auto minmax(0, 1fr)]',
           alignItems: 'stretch',
           gap: '4',
           width: 'full',
@@ -180,6 +180,7 @@ function MatchupCard({
         display: 'flex',
         flexDirection: 'column',
         gap: '3',
+        minWidth: '0',
         minHeight: '0',
         borderRadius: 'md',
         borderWidth: '1px',

--- a/src/server/api/routers/links.ts
+++ b/src/server/api/routers/links.ts
@@ -44,6 +44,13 @@ export const linksRouter = createTRPCRouter({
               predicate: true,
               recordUpdatedAt: true,
             },
+            with: {
+              target: {
+                columns: {
+                  eloScore: true,
+                },
+              },
+            },
           },
           incomingLinks: {
             columns: {
@@ -53,6 +60,13 @@ export const linksRouter = createTRPCRouter({
               predicate: true,
               recordUpdatedAt: true,
             },
+            with: {
+              source: {
+                columns: {
+                  eloScore: true,
+                },
+              },
+            },
           },
         },
       });
@@ -60,7 +74,15 @@ export const linksRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' });
       }
 
-      return recordWithLinks;
+      return {
+        id: recordWithLinks.id,
+        outgoingLinks: recordWithLinks.outgoingLinks
+          .toSorted((a, b) => b.target.eloScore - a.target.eloScore || a.targetId - b.targetId)
+          .map(({ target: _target, ...link }) => link),
+        incomingLinks: recordWithLinks.incomingLinks
+          .toSorted((a, b) => b.source.eloScore - a.source.eloScore || a.sourceId - b.sourceId)
+          .map(({ source: _source, ...link }) => link),
+      };
     }),
 
   /**


### PR DESCRIPTION
Arena matchups can shift into uneven columns when record content has a wide intrinsic size, while relationship previews can omit stronger linked records because their ten-item cutoff follows database order.

- Keeps both matchup cards on equal-width tracks regardless of content width.
- Orders linked records by descending Elo before truncation and refreshes that ordering after matchup results.
- Bumps the application version to 0.8.1.