### PR TITLE
Migrate to the TanStack-native tRPC client and fix stale matchup counts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,8 +17,8 @@
         "@tanstack/react-router-with-query": "~1.130.17",
         "@tanstack/react-start": "~1.168.34",
         "@trpc/client": "~11.18.0",
-        "@trpc/react-query": "~11.18.0",
         "@trpc/server": "~11.18.0",
+        "@trpc/tanstack-react-query": "~11.18.0",
         "@types/bun": "~1.3.14",
         "airtable": "~0.12.2",
         "cmdk": "~1.1.1",
@@ -698,9 +698,9 @@
 
     "@trpc/client": ["@trpc/client@11.18.0", "", { "peerDependencies": { "@trpc/server": "11.18.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-wOqeg3Fvl25V1ZisQhUD3K8G60ZJDlSGJNSyeXrLH24xAo5w6GSR2Kzb1cSNY9Y+IQ2YZvYGZstBU+V/ulo/ow=="],
 
-    "@trpc/react-query": ["@trpc/react-query@11.18.0", "", { "peerDependencies": { "@tanstack/react-query": "^5.80.3", "@trpc/client": "11.18.0", "@trpc/server": "11.18.0", "react": ">=18.2.0", "typescript": ">=5.7.2" } }, "sha512-C1+Wwm2pCeUJucI+bnFpxGYjNuvV+ko1BC1T9tUxBVdrhHRCdn9ubxdevdLSAa49XRJRJiZnSuzl3Ys/yvs1vg=="],
-
     "@trpc/server": ["@trpc/server@11.18.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q=="],
+
+    "@trpc/tanstack-react-query": ["@trpc/tanstack-react-query@11.18.0", "", { "peerDependencies": { "@tanstack/react-query": "^5.80.3", "@trpc/client": "11.18.0", "@trpc/server": "11.18.0", "react": ">=18.2.0", "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-dm5xIlN0SEzJAbQ34EHdb1Kgd/zWZ63ZMviQEw3WCWCIPz8MjLKAhquncPcn+YxFUJa+Qi4qatdGFymmM4HmAQ=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",
@@ -54,8 +54,8 @@
     "@tanstack/react-router-with-query": "~1.130.17",
     "@tanstack/react-start": "~1.168.34",
     "@trpc/client": "~11.18.0",
-    "@trpc/react-query": "~11.18.0",
     "@trpc/server": "~11.18.0",
+    "@trpc/tanstack-react-query": "~11.18.0",
     "@types/bun": "~1.3.14",
     "airtable": "~0.12.2",
     "cmdk": "~1.1.1",

--- a/src/app/components/basket.tsx
+++ b/src/app/components/basket.tsx
@@ -1,6 +1,7 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { ClipboardCopyIcon, ShoppingBasketIcon, Trash2Icon, XIcon } from 'lucide-react';
 import { toast } from 'sonner';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { removeManyFromBasket, useBasket } from '@/lib/hooks/use-basket';
 import type { DbId } from '@/shared/types/api';
 import { styled } from '@/styled-system/jsx';
@@ -54,7 +55,8 @@ function BasketItem({ id, onRemove }: { id: DbId; onRemove: (id: DbId) => void }
 
 export function Basket() {
   const basket = useBasket();
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
   const copyIds = async () => {
     try {
@@ -68,7 +70,9 @@ export function Basket() {
 
   const copyJson = async () => {
     const ids = basket.ids;
-    const results = await Promise.allSettled(ids.map((id) => utils.records.get.ensureData({ id })));
+    const results = await Promise.allSettled(
+      ids.map((id) => queryClient.ensureQueryData(trpc.records.get.queryOptions({ id })))
+    );
 
     const records: unknown[] = [];
     const missingIds: DbId[] = [];

--- a/src/app/lib/hooks/elo-mutations.ts
+++ b/src/app/lib/hooks/elo-mutations.ts
@@ -1,18 +1,25 @@
-import { trpc } from '@/app/trpc';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/app/trpc';
 
 /**
- * Submit an ELO matchup (win/loss or draw). Invalidate participant records and
- * queries whose ordering depends on ELO scores.
+ * Submit an ELO matchup (win/loss or draw). Patch the participants' cached
+ * records from the authoritative response, and invalidate queries whose
+ * ordering depends on ELO scores.
  */
 export function useSubmitMatchup() {
-  const utils = trpc.useUtils();
-  return trpc.elo.submitMatchup.useMutation({
-    onSuccess: ({ results }) => {
-      for (const { id } of results) {
-        void utils.records.get.invalidate({ id });
-      }
-      void utils.records.list.invalidate();
-      void utils.links.listForRecord.invalidate();
-    },
-  });
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.elo.submitMatchup.mutationOptions({
+      onSuccess: ({ results }) => {
+        for (const { id, eloScore, matchupCount } of results) {
+          queryClient.setQueryData(trpc.records.get.queryKey({ id }), (prev) =>
+            prev ? { ...prev, eloScore, matchupCount } : prev
+          );
+        }
+        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
+        void queryClient.invalidateQueries(trpc.links.listForRecord.pathFilter());
+      },
+    })
+  );
 }

--- a/src/app/lib/hooks/elo-mutations.ts
+++ b/src/app/lib/hooks/elo-mutations.ts
@@ -3,8 +3,8 @@ import { useTRPC } from '@/app/trpc';
 
 /**
  * Submit an ELO matchup (win/loss or draw). Patch the participants' cached
- * records from the authoritative response, and invalidate queries whose
- * ordering depends on ELO scores.
+ * records from the authoritative response so scores update ahead of the
+ * global invalidation refetch.
  */
 export function useSubmitMatchup() {
   const trpc = useTRPC();
@@ -17,8 +17,6 @@ export function useSubmitMatchup() {
             prev ? { ...prev, eloScore, matchupCount } : prev
           );
         }
-        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
-        void queryClient.invalidateQueries(trpc.links.listForRecord.pathFilter());
       },
     })
   );

--- a/src/app/lib/hooks/link-mutations.ts
+++ b/src/app/lib/hooks/link-mutations.ts
@@ -1,166 +1,168 @@
 import { getInverse, PREDICATES, type PredicateSlug } from '@hozo';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { trpc } from '@/app/trpc';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/app/trpc';
 import type { DbId } from '@/shared/types/api';
 import type { RecordLinks } from '@/shared/types/domain';
 
+/** Placeholder ids for optimistic links; negative so they never collide with db ids. */
+let nextOptimisticLinkId = -1;
+
 export function useUpsertLink() {
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-  return trpc.links.upsert.useMutation({
-    onMutate: async ({ sourceId, targetId, predicate, id }) => {
-      // For updates, skip optimistic updates entirely - let the server handle it
-      // This avoids the complexity of tracking which direction the link was originally
-      // and how the server's canonicalization might change it
-      if (id) {
-        await Promise.all([
-          utils.links.listForRecord.invalidate({ id: sourceId }),
-          utils.links.listForRecord.invalidate({ id: targetId }),
-        ]);
-        return {};
-      }
-
-      // For new links, we need to predict the server's canonicalization
-      await Promise.all([
-        utils.links.listForRecord.cancel({ id: sourceId }),
-        utils.links.listForRecord.cancel({ id: targetId }),
-      ]);
-
-      const prevSource = utils.links.listForRecord.getData({ id: sourceId });
-      const prevTarget = utils.links.listForRecord.getData({ id: targetId });
-
-      // Check if the predicate will be canonicalized by the server
-      const predicateDef = PREDICATES[predicate];
-      let finalSourceId = sourceId;
-      let finalTargetId = targetId;
-      let finalPredicate: PredicateSlug = predicate;
-
-      if (!predicateDef.canonical) {
-        // The server will flip this - mirror that behavior
-        const inversePredicate = getInverse(predicate);
-        if (inversePredicate.canonical) {
-          finalSourceId = targetId;
-          finalTargetId = sourceId;
-          finalPredicate = inversePredicate.slug as PredicateSlug;
+  return useMutation(
+    trpc.links.upsert.mutationOptions({
+      onMutate: async ({ sourceId, targetId, predicate, id }) => {
+        // For updates, skip optimistic updates entirely - let the server handle it
+        // This avoids the complexity of tracking which direction the link was originally
+        // and how the server's canonicalization might change it
+        if (id) {
+          await Promise.all([
+            queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: sourceId })),
+            queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: targetId })),
+          ]);
+          return {};
         }
-      }
 
-      const optimisticId = -Date.now();
-      const link = {
-        id: optimisticId,
-        sourceId: finalSourceId,
-        targetId: finalTargetId,
-        predicate: finalPredicate,
-        recordUpdatedAt: new Date(),
-      };
+        // For new links, we need to predict the server's canonicalization
+        await Promise.all([
+          queryClient.cancelQueries(trpc.links.listForRecord.queryFilter({ id: sourceId })),
+          queryClient.cancelQueries(trpc.links.listForRecord.queryFilter({ id: targetId })),
+        ]);
 
-      // Add the link to the correct arrays based on the final (canonicalized) direction
-      utils.links.listForRecord.setData({ id: finalSourceId }, (data) => {
-        if (!data) return data;
-        return {
-          ...data,
-          outgoingLinks: [...data.outgoingLinks, link],
+        const prevSource = queryClient.getQueryData(
+          trpc.links.listForRecord.queryKey({ id: sourceId })
+        );
+        const prevTarget = queryClient.getQueryData(
+          trpc.links.listForRecord.queryKey({ id: targetId })
+        );
+
+        // Check if the predicate will be canonicalized by the server
+        const predicateDef = PREDICATES[predicate];
+        let finalSourceId = sourceId;
+        let finalTargetId = targetId;
+        let finalPredicate: PredicateSlug = predicate;
+
+        if (!predicateDef.canonical) {
+          // The server will flip this - mirror that behavior
+          const inversePredicate = getInverse(predicate);
+          if (inversePredicate.canonical) {
+            finalSourceId = targetId;
+            finalTargetId = sourceId;
+            finalPredicate = inversePredicate.slug as PredicateSlug;
+          }
+        }
+
+        const link = {
+          id: nextOptimisticLinkId--,
+          sourceId: finalSourceId,
+          targetId: finalTargetId,
+          predicate: finalPredicate,
+          recordUpdatedAt: new Date(),
         };
-      });
-      utils.links.listForRecord.setData({ id: finalTargetId }, (data) => {
-        if (!data) return data;
-        return {
-          ...data,
-          incomingLinks: [...data.incomingLinks, link],
-        };
-      });
 
-      return { prevSource, prevTarget };
-    },
-    onSuccess: (row) => {
-      const { sourceId, targetId } = row;
+        // Add the link to the correct arrays based on the final (canonicalized) direction
+        queryClient.setQueryData(
+          trpc.links.listForRecord.queryKey({ id: finalSourceId }),
+          (data) => {
+            if (!data) return data;
+            return {
+              ...data,
+              outgoingLinks: [...data.outgoingLinks, link],
+            };
+          }
+        );
+        queryClient.setQueryData(
+          trpc.links.listForRecord.queryKey({ id: finalTargetId }),
+          (data) => {
+            if (!data) return data;
+            return {
+              ...data,
+              incomingLinks: [...data.incomingLinks, link],
+            };
+          }
+        );
 
-      void utils.links.listForRecord.invalidate({ id: sourceId });
-      void utils.links.listForRecord.invalidate({ id: targetId });
+        return { prevSource, prevTarget };
+      },
+      onSuccess: (row) => {
+        const { sourceId, targetId } = row;
 
-      void utils.search.byRecordId.invalidate({ id: sourceId });
-      void utils.search.byRecordId.invalidate({ id: targetId });
+        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: targetId }));
 
-      void utils.records.tree.invalidate({ id: sourceId });
-      void utils.records.tree.invalidate({ id: targetId });
+        void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: targetId }));
 
-      void utils.links.map.invalidate(undefined, {
-        predicate: (q) => {
-          const input = q.queryKey[1]?.input;
+        void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id: targetId }));
 
-          if (!input?.recordIds) return false;
-
-          const ids = input.recordIds.filter((n): n is DbId => n !== undefined);
-
-          return ids.includes(sourceId) || ids.includes(targetId);
-        },
-      });
-    },
-    onError: (err, variables, ctx) => {
-      if (ctx?.prevSource) {
-        utils.links.listForRecord.setData({ id: variables.sourceId }, ctx.prevSource);
-      }
-      if (ctx?.prevTarget) {
-        utils.links.listForRecord.setData({ id: variables.targetId }, ctx.prevTarget);
-      }
-      toast.error(err instanceof Error ? err.message : 'Failed to upsert link');
-    },
-  });
+        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
+      },
+      onError: (_err, variables, ctx) => {
+        if (ctx?.prevSource) {
+          queryClient.setQueryData(
+            trpc.links.listForRecord.queryKey({ id: variables.sourceId }),
+            ctx.prevSource
+          );
+        }
+        if (ctx?.prevTarget) {
+          queryClient.setQueryData(
+            trpc.links.listForRecord.queryKey({ id: variables.targetId }),
+            ctx.prevTarget
+          );
+        }
+      },
+    })
+  );
 }
 
 export function useDeleteLinks() {
-  const utils = trpc.useUtils();
-  const qc = useQueryClient();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-  return trpc.links.delete.useMutation({
-    onMutate: (ids) => {
-      const entries = qc.getQueriesData<RecordLinks>({
-        queryKey: ['links', 'listForRecord'],
-      });
-      const previous = entries.map(([key, data]) => [key, data] as const);
-      const idSet = new Set(ids);
-      entries.forEach(([key, data]) => {
-        if (!data) return;
-        qc.setQueryData(key, {
-          ...data,
-          outgoingLinks: data.outgoingLinks.filter((l) => !idSet.has(l.id)),
-          incomingLinks: data.incomingLinks.filter((l) => !idSet.has(l.id)),
+  return useMutation(
+    trpc.links.delete.mutationOptions({
+      onMutate: (ids) => {
+        const entries = queryClient.getQueriesData<RecordLinks>(
+          trpc.links.listForRecord.pathFilter()
+        );
+        const previous = entries.map(([key, data]) => [key, data] as const);
+        const idSet = new Set(ids);
+        entries.forEach(([key, data]) => {
+          if (!data) return;
+          queryClient.setQueryData(key, {
+            ...data,
+            outgoingLinks: data.outgoingLinks.filter((l) => !idSet.has(l.id)),
+            incomingLinks: data.incomingLinks.filter((l) => !idSet.has(l.id)),
+          });
         });
-      });
-      return { previous };
-    },
-    onSuccess: (rows) => {
-      /* collect every record whose link list changed */
-      const touched = new Set<DbId>();
-      rows.forEach(({ sourceId, targetId }) => {
-        touched.add(sourceId);
-        touched.add(targetId);
-      });
+        return { previous };
+      },
+      onSuccess: (rows) => {
+        /* collect every record whose link list changed */
+        const touched = new Set<DbId>();
+        rows.forEach(({ sourceId, targetId }) => {
+          touched.add(sourceId);
+          touched.add(targetId);
+        });
 
-      /* 1 ▸ invalidate per-record link lists */
-      touched.forEach((id) => {
-        void utils.links.listForRecord.invalidate({ id });
-        void utils.records.tree.invalidate({ id });
-        void utils.search.byRecordId.invalidate({ id });
-      });
+        /* 1 ▸ invalidate per-record link lists */
+        touched.forEach((id) => {
+          void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id }));
+          void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id }));
+          void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id }));
+        });
 
-      /* 2 ▸ drop any cached map that overlaps the touched set */
-      void utils.links.map.invalidate(undefined, {
-        predicate: (q) => {
-          const input = q.queryKey[1]?.input;
-          if (!input?.recordIds) return false;
-
-          const ids = input.recordIds.filter((n): n is DbId => n !== undefined);
-          return ids.some((id) => touched.has(id));
-        },
-      });
-    },
-    onError: (err, _ids, ctx) => {
-      ctx?.previous.forEach(([key, data]) => {
-        qc.setQueryData(key, data);
-      });
-      toast.error(err instanceof Error ? err.message : 'Failed to delete links');
-    },
-  });
+        /* 2 ▸ drop any cached map that may reference the deleted links */
+        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
+      },
+      onError: (_err, _ids, ctx) => {
+        ctx?.previous.forEach(([key, data]) => {
+          queryClient.setQueryData(key, data);
+        });
+      },
+    })
+  );
 }

--- a/src/app/lib/hooks/link-mutations.ts
+++ b/src/app/lib/hooks/link-mutations.ts
@@ -86,19 +86,11 @@ export function useUpsertLink() {
 
         return { prevSource, prevTarget };
       },
-      onSuccess: (row) => {
-        const { sourceId, targetId } = row;
-
-        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: sourceId }));
-        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: targetId }));
-
+      onSuccess: ({ sourceId, targetId }) => {
+        // Similarity search is excluded from global invalidation but links
+        // change its results (url-linked records rank as similar).
         void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: sourceId }));
         void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: targetId }));
-
-        void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id: sourceId }));
-        void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id: targetId }));
-
-        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
       },
       onError: (_err, variables, ctx) => {
         if (ctx?.prevSource) {
@@ -141,22 +133,16 @@ export function useDeleteLinks() {
         return { previous };
       },
       onSuccess: (rows) => {
-        /* collect every record whose link list changed */
+        // Similarity search is excluded from global invalidation but links
+        // change its results.
         const touched = new Set<DbId>();
         rows.forEach(({ sourceId, targetId }) => {
           touched.add(sourceId);
           touched.add(targetId);
         });
-
-        /* 1 ▸ invalidate per-record link lists */
         touched.forEach((id) => {
-          void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id }));
-          void queryClient.invalidateQueries(trpc.records.tree.queryFilter({ id }));
           void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id }));
         });
-
-        /* 2 ▸ drop any cached map that may reference the deleted links */
-        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
       },
       onError: (_err, _ids, ctx) => {
         ctx?.previous.forEach(([key, data]) => {

--- a/src/app/lib/hooks/media-mutations.ts
+++ b/src/app/lib/hooks/media-mutations.ts
@@ -1,33 +1,40 @@
-import { trpc } from '@/app/trpc';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/app/trpc';
 import type { DbId } from '@/shared/types/api';
 
 export function useCreateMedia(id: DbId) {
-  const utils = trpc.useUtils();
-  return trpc.media.create.useMutation({
-    onSuccess: (data) => {
-      utils.records.get.setData({ id }, (prev) => {
-        if (!prev) return undefined;
-        return { ...prev, media: [...(prev.media ?? []), data] };
-      });
-    },
-  });
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.media.create.mutationOptions({
+      onSuccess: (data) => {
+        queryClient.setQueryData(trpc.records.get.queryKey({ id }), (prev) => {
+          if (!prev) return undefined;
+          return { ...prev, media: [...(prev.media ?? []), data] };
+        });
+      },
+    })
+  );
 }
 
 export function useDeleteMedia() {
-  const utils = trpc.useUtils();
-  return trpc.media.delete.useMutation({
-    onSuccess: (deletedMedia) => {
-      for (const m of deletedMedia) {
-        if (m.recordId) {
-          utils.records.get.setData({ id: m.recordId }, (prev) => {
-            if (!prev) return undefined;
-            return {
-              ...prev,
-              media: prev.media?.filter((p) => p.id !== m.id),
-            };
-          });
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.media.delete.mutationOptions({
+      onSuccess: (deletedMedia) => {
+        for (const m of deletedMedia) {
+          if (m.recordId) {
+            queryClient.setQueryData(trpc.records.get.queryKey({ id: m.recordId }), (prev) => {
+              if (!prev) return undefined;
+              return {
+                ...prev,
+                media: prev.media?.filter((p) => p.id !== m.id),
+              };
+            });
+          }
         }
-      }
-    },
-  });
+      },
+    })
+  );
 }

--- a/src/app/lib/hooks/record-mutations.ts
+++ b/src/app/lib/hooks/record-mutations.ts
@@ -41,12 +41,6 @@ export function useBulkUpdate() {
         });
         return { previous };
       },
-      onSuccess: (ids) => {
-        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
-        ids.forEach(
-          (id) => void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id }))
-        );
-      },
       onError: (_err, _vars, ctx) => {
         ctx?.previous.forEach((data, id) => {
           queryClient.setQueryData(trpc.records.get.queryKey({ id }), data);
@@ -76,11 +70,9 @@ export function useUpsertRecord() {
         return { previous };
       },
       onSuccess: (row) => {
-        /* patch point cache */
+        // Patch the point cache with the authoritative row ahead of the
+        // global invalidation refetch.
         queryClient.setQueryData(trpc.records.get.queryKey({ id: row.id }), row);
-
-        /* refresh ID tables & search index */
-        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
       },
       onError: (_err, input, ctx) => {
         if (input.id !== undefined && ctx?.previous) {
@@ -144,11 +136,6 @@ export function useDeleteRecords() {
 
         // Cleanup is already done in onMutate, just ensure consistency
         rows.forEach(({ id }) => removeRecordQueries(id));
-
-        /* Invalidate targeted caches that might reference deleted records */
-        void queryClient.invalidateQueries(trpc.records.tree.pathFilter()); // Tree queries may contain deleted records as children
-        void queryClient.invalidateQueries(trpc.links.listForRecord.pathFilter()); // Link queries may reference deleted records
-        void queryClient.invalidateQueries(trpc.links.map.pathFilter()); // Link maps may reference deleted records
       },
       onError: (_err, _ids, ctx) => {
         ctx?.previousRecords.forEach((data, id) => {
@@ -212,10 +199,10 @@ export function useMergeRecords() {
 
         return { previousSource, previousTarget, previousLists: entries };
       },
-      onSuccess: ({ updatedRecord, deletedRecordId, touchedIds, snapshot }) => {
+      onSuccess: ({ updatedRecord, deletedRecordId, snapshot }) => {
         replaceBasketId(deletedRecordId, updatedRecord.id);
 
-        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: updatedRecord.id }));
+        // Similarity search is excluded from global invalidation.
         void queryClient.invalidateQueries(
           trpc.search.byRecordId.queryFilter({ id: updatedRecord.id })
         );
@@ -229,18 +216,6 @@ export function useMergeRecords() {
         // mark as permanently gone
         queryClient.setQueryData(deletedKey, () => undefined);
         queryClient.setQueryDefaults(deletedKey, { staleTime: Infinity, retry: false });
-
-        /* per-record link lists */
-        touchedIds.forEach(
-          (id) => void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id }))
-        );
-
-        /* maps that may reference the merged records */
-        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
-
-        /* record-ID tables */
-        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
-        void queryClient.invalidateQueries(trpc.records.tree.pathFilter());
 
         /* undo toast */
         toast('Records merged', {
@@ -291,16 +266,9 @@ function useUndoMerge() {
         const sourceKey = trpc.records.get.queryKey({ id: sourceId });
         queryClient.setQueryDefaults(sourceKey, { staleTime: undefined, retry: undefined });
 
-        // Invalidate caches for both records
-        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: sourceId }));
-        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: targetId }));
+        // Similarity search is excluded from global invalidation.
         void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: sourceId }));
         void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: targetId }));
-        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
-        void queryClient.invalidateQueries(trpc.records.tree.pathFilter());
-        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: sourceId }));
-        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: targetId }));
-        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
 
         // Navigate back to the restored source record
         void navigate({

--- a/src/app/lib/hooks/record-mutations.ts
+++ b/src/app/lib/hooks/record-mutations.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
-import { useTRPC } from '@/app/trpc';
+import { useTRPC, type TRPCProxy } from '@/app/trpc';
 import { removeManyFromBasket, replaceBasketId } from '@/lib/hooks/use-basket';
 import { mergeRecords } from '@/shared/lib/merge-records';
 import type { DbId, IdParamList } from '@/shared/types/api';
@@ -18,6 +18,19 @@ function stripUndefined<T extends object>(obj: T): Partial<T> {
     if (obj[key] !== undefined) result[key] = obj[key];
   }
   return result;
+}
+
+/**
+ * Drop a deleted (or merged-away) record's point queries from the cache.
+ * Removed queries are invisible to `invalidateQueries`, so the global
+ * invalidate-on-mutation default can't force-refetch a record the server
+ * no longer has. Callers snapshot first and restore in onError.
+ */
+function removeRecordQueries(queryClient: QueryClient, trpc: TRPCProxy, id: DbId) {
+  queryClient.removeQueries({ queryKey: trpc.records.get.queryKey({ id }), exact: true });
+  queryClient.removeQueries({ queryKey: trpc.search.byRecordId.queryKey({ id }), exact: true });
+  queryClient.removeQueries({ queryKey: trpc.records.tree.queryKey({ id }), exact: true });
+  queryClient.removeQueries({ queryKey: trpc.links.listForRecord.queryKey({ id }), exact: true });
 }
 
 export function useBulkUpdate() {
@@ -87,16 +100,6 @@ export function useDeleteRecords() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
 
-  const removeRecordQueries = (id: DbId) => {
-    queryClient.removeQueries({ queryKey: trpc.records.get.queryKey({ id }), exact: true });
-    queryClient.removeQueries({ queryKey: trpc.search.byRecordId.queryKey({ id }), exact: true });
-    queryClient.removeQueries({ queryKey: trpc.records.tree.queryKey({ id }), exact: true });
-    queryClient.removeQueries({
-      queryKey: trpc.links.listForRecord.queryKey({ id }),
-      exact: true,
-    });
-  };
-
   return useMutation(
     trpc.records.delete.mutationOptions({
       onMutate: async (ids) => {
@@ -115,7 +118,7 @@ export function useDeleteRecords() {
         const previousRecords = new Map<DbId, RecordGet | undefined>();
         ids.forEach((id) => {
           previousRecords.set(id, queryClient.getQueryData(trpc.records.get.queryKey({ id })));
-          removeRecordQueries(id);
+          removeRecordQueries(queryClient, trpc, id);
         });
 
         // Optimistically remove deleted records from all record lists
@@ -135,7 +138,7 @@ export function useDeleteRecords() {
         removeManyFromBasket(rows.map(({ id }) => id));
 
         // Cleanup is already done in onMutate, just ensure consistency
-        rows.forEach(({ id }) => removeRecordQueries(id));
+        rows.forEach(({ id }) => removeRecordQueries(queryClient, trpc, id));
       },
       onError: (_err, _ids, ctx) => {
         ctx?.previousRecords.forEach((data, id) => {
@@ -182,10 +185,10 @@ export function useMergeRecords() {
 
           // Update the target record with merged data
           queryClient.setQueryData(trpc.records.get.queryKey({ id: targetId }), optimisticUpdate);
-
-          // Remove the source record from cache
-          queryClient.setQueryData(trpc.records.get.queryKey({ id: sourceId }), () => undefined);
         }
+
+        // The merge deletes the source record server-side.
+        removeRecordQueries(queryClient, trpc, sourceId);
 
         // Optimistically remove source record from all record lists
         const entries = queryClient.getQueriesData<IdParamList>(trpc.records.list.pathFilter());
@@ -207,15 +210,11 @@ export function useMergeRecords() {
           trpc.search.byRecordId.queryFilter({ id: updatedRecord.id })
         );
 
-        /* freeze the deleted ID so nothing refetches it */
-        const deletedKey = trpc.records.get.queryKey({ id: deletedRecordId });
-
-        // stop any in-flight request
-        void queryClient.cancelQueries({ queryKey: deletedKey, exact: true });
-
-        // mark as permanently gone
-        queryClient.setQueryData(deletedKey, () => undefined);
-        queryClient.setQueryDefaults(deletedKey, { staleTime: Infinity, retry: false });
+        // A RecordLink pointing at the deleted id can still mount from stale
+        // links data and fetch it; don't retry the inevitable not-found.
+        queryClient.setQueryDefaults(trpc.records.get.queryKey({ id: deletedRecordId }), {
+          retry: false,
+        });
 
         /* undo toast */
         toast('Records merged', {
@@ -262,9 +261,9 @@ function useUndoMerge() {
         const sourceId = sourceRecord.id;
         const targetId = targetRecord.id;
 
-        // Remove the staleTime: Infinity freeze on the source record
+        // The source record exists again; lift its retry: false default
         const sourceKey = trpc.records.get.queryKey({ id: sourceId });
-        queryClient.setQueryDefaults(sourceKey, { staleTime: undefined, retry: undefined });
+        queryClient.setQueryDefaults(sourceKey, { retry: undefined });
 
         // Similarity search is excluded from global invalidation.
         void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: sourceId }));

--- a/src/app/lib/hooks/record-mutations.ts
+++ b/src/app/lib/hooks/record-mutations.ts
@@ -1,314 +1,301 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { getQueryKey } from '@trpc/react-query';
 import { toast } from 'sonner';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { removeManyFromBasket, replaceBasketId } from '@/lib/hooks/use-basket';
 import { mergeRecords } from '@/shared/lib/merge-records';
 import type { DbId, IdParamList } from '@/shared/types/api';
 import type { RecordGet } from '@/shared/types/domain';
 
 export function useBulkUpdate() {
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-  return trpc.records.bulkUpdate.useMutation({
-    onMutate: ({ ids, data }) => {
-      // Fire cancellations but don't await - keeps onMutate synchronous
-      // to avoid race conditions with navigation
-      ids.forEach((id) => void utils.records.get.cancel({ id }));
+  return useMutation(
+    trpc.records.bulkUpdate.mutationOptions({
+      onMutate: ({ ids, data }) => {
+        // Fire cancellations but don't await - keeps onMutate synchronous
+        // to avoid race conditions with navigation
+        ids.forEach((id) => void queryClient.cancelQueries(trpc.records.get.queryFilter({ id })));
 
-      const previous = new Map<DbId, RecordGet | undefined>();
-      ids.forEach((id) => {
-        const cached = utils.records.get.getData({ id });
-        previous.set(id, cached);
-        if (cached) {
-          utils.records.get.setData({ id }, { ...cached, ...data });
-        }
-      });
-      return { previous };
-    },
-    onSuccess: (ids) => {
-      void utils.records.list.invalidate();
-      ids.forEach((id) => void utils.records.get.invalidate({ id }));
-    },
-    onError: (err, _vars, ctx) => {
-      ctx?.previous.forEach((data, id) => {
-        utils.records.get.setData({ id }, data);
-      });
-      toast.error(err instanceof Error ? err.message : 'Failed to update records');
-    },
-  });
+        const previous = new Map<DbId, RecordGet | undefined>();
+        ids.forEach((id) => {
+          const cached = queryClient.getQueryData(trpc.records.get.queryKey({ id }));
+          previous.set(id, cached);
+          if (cached) {
+            queryClient.setQueryData(trpc.records.get.queryKey({ id }), { ...cached, ...data });
+          }
+        });
+        return { previous };
+      },
+      onSuccess: (ids) => {
+        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
+        ids.forEach(
+          (id) => void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id }))
+        );
+      },
+      onError: (_err, _vars, ctx) => {
+        ctx?.previous.forEach((data, id) => {
+          queryClient.setQueryData(trpc.records.get.queryKey({ id }), data);
+        });
+      },
+    })
+  );
 }
 
 export function useUpsertRecord() {
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-  return trpc.records.upsert.useMutation({
-    onMutate: async (input) => {
-      if (input.id === undefined) return;
-      await utils.records.get.cancel({ id: input.id });
-      const previous = utils.records.get.getData({ id: input.id });
-      if (previous) {
-        const changes = input as Partial<RecordGet>;
-        utils.records.get.setData({ id: input.id }, (p) => (p ? { ...p, ...changes } : p));
-      }
-      return { previous };
-    },
-    onSuccess: (row) => {
-      /* patch point cache */
-      utils.records.get.setData({ id: row.id }, row);
+  return useMutation(
+    trpc.records.upsert.mutationOptions({
+      onMutate: async (input) => {
+        if (input.id === undefined) return;
+        await queryClient.cancelQueries(trpc.records.get.queryFilter({ id: input.id }));
+        const previous = queryClient.getQueryData(trpc.records.get.queryKey({ id: input.id }));
+        if (previous) {
+          const changes = input as Partial<RecordGet>;
+          queryClient.setQueryData(trpc.records.get.queryKey({ id: input.id }), (p) =>
+            p ? { ...p, ...changes } : p
+          );
+        }
+        return { previous };
+      },
+      onSuccess: (row) => {
+        /* patch point cache */
+        queryClient.setQueryData(trpc.records.get.queryKey({ id: row.id }), row);
 
-      /* refresh ID tables & search index */
-      void utils.records.list.invalidate();
-    },
-    onError: (err, input, ctx) => {
-      if (input.id !== undefined && ctx?.previous) {
-        utils.records.get.setData({ id: input.id }, ctx.previous);
-      }
-      toast.error(err instanceof Error ? err.message : 'Failed to update record');
-    },
-  });
+        /* refresh ID tables & search index */
+        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
+      },
+      onError: (_err, input, ctx) => {
+        if (input.id !== undefined && ctx?.previous) {
+          queryClient.setQueryData(trpc.records.get.queryKey({ id: input.id }), ctx.previous);
+        }
+      },
+    })
+  );
 }
 
 export function useDeleteRecords() {
-  const qc = useQueryClient();
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-  return trpc.records.delete.useMutation({
-    onMutate: async (ids) => {
-      await Promise.all(
-        ids.map((id) =>
-          qc.cancelQueries({
-            queryKey: utils.records.get.queryOptions({ id }).queryKey,
-            exact: true,
-          })
-        )
-      );
+  const removeRecordQueries = (id: DbId) => {
+    queryClient.removeQueries({ queryKey: trpc.records.get.queryKey({ id }), exact: true });
+    queryClient.removeQueries({ queryKey: trpc.search.byRecordId.queryKey({ id }), exact: true });
+    queryClient.removeQueries({ queryKey: trpc.records.tree.queryKey({ id }), exact: true });
+    queryClient.removeQueries({
+      queryKey: trpc.links.listForRecord.queryKey({ id }),
+      exact: true,
+    });
+  };
 
-      // Cancel any pending mutations for these records
-      qc.getMutationCache().clear();
+  return useMutation(
+    trpc.records.delete.mutationOptions({
+      onMutate: async (ids) => {
+        await Promise.all(
+          ids.map((id) =>
+            queryClient.cancelQueries({
+              queryKey: trpc.records.get.queryKey({ id }),
+              exact: true,
+            })
+          )
+        );
 
-      const previousRecords = new Map<DbId, RecordGet | undefined>();
-      ids.forEach((id) => {
-        const data = qc.getQueryData(utils.records.get.queryOptions({ id }).queryKey);
-        previousRecords.set(id, data);
-        qc.removeQueries({
-          queryKey: utils.records.get.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-        qc.removeQueries({
-          queryKey: utils.search.byRecordId.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-        qc.removeQueries({
-          queryKey: utils.records.tree.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-        qc.removeQueries({
-          queryKey: utils.links.listForRecord.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-      });
+        // Cancel any pending mutations for these records
+        queryClient.getMutationCache().clear();
 
-      // Optimistically remove deleted records from all record lists
-      const idSet = new Set(ids);
-      const removeFromLists = (queryKey: readonly unknown[]) => {
-        const entries = qc.getQueriesData<IdParamList>({ queryKey });
+        const previousRecords = new Map<DbId, RecordGet | undefined>();
+        ids.forEach((id) => {
+          previousRecords.set(id, queryClient.getQueryData(trpc.records.get.queryKey({ id })));
+          removeRecordQueries(id);
+        });
+
+        // Optimistically remove deleted records from all record lists
+        const idSet = new Set(ids);
+        const entries = queryClient.getQueriesData<IdParamList>(trpc.records.list.pathFilter());
         entries.forEach(([key, data]) => {
           if (!data) return;
-          qc.setQueryData(key, { ...data, ids: data.ids.filter(({ id }) => !idSet.has(id)) });
+          queryClient.setQueryData(key, {
+            ...data,
+            ids: data.ids.filter(({ id }) => !idSet.has(id)),
+          });
         });
-        return entries.map(([key, data]) => [key, data] as const);
-      };
 
-      const previousLists = removeFromLists(getQueryKey(trpc.records.list, undefined, 'query'));
+        return { previousRecords, previousLists: entries };
+      },
+      onSuccess: (rows) => {
+        removeManyFromBasket(rows.map(({ id }) => id));
 
-      return { previousRecords, previousLists };
-    },
-    onSuccess: (rows) => {
-      removeManyFromBasket(rows.map(({ id }) => id));
+        // Cleanup is already done in onMutate, just ensure consistency
+        rows.forEach(({ id }) => removeRecordQueries(id));
 
-      // Cleanup is already done in onMutate, just ensure consistency
-      rows.forEach(({ id }) => {
-        qc.removeQueries({
-          queryKey: utils.records.get.queryOptions({ id }).queryKey,
-          exact: true,
+        /* Invalidate targeted caches that might reference deleted records */
+        void queryClient.invalidateQueries(trpc.records.tree.pathFilter()); // Tree queries may contain deleted records as children
+        void queryClient.invalidateQueries(trpc.links.listForRecord.pathFilter()); // Link queries may reference deleted records
+        void queryClient.invalidateQueries(trpc.links.map.pathFilter()); // Link maps may reference deleted records
+      },
+      onError: (_err, _ids, ctx) => {
+        ctx?.previousRecords.forEach((data, id) => {
+          queryClient.setQueryData(trpc.records.get.queryKey({ id }), data);
         });
-        qc.removeQueries({
-          queryKey: utils.search.byRecordId.queryOptions({ id }).queryKey,
-          exact: true,
+        ctx?.previousLists.forEach(([key, data]) => {
+          queryClient.setQueryData(key, data);
         });
-        qc.removeQueries({
-          queryKey: utils.records.tree.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-        qc.removeQueries({
-          queryKey: utils.links.listForRecord.queryOptions({ id }).queryKey,
-          exact: true,
-        });
-      });
-
-      /* Invalidate targeted caches that might reference deleted records */
-      void utils.records.tree.invalidate(); // Tree queries may contain deleted records as children
-      void utils.links.listForRecord.invalidate(); // Link queries may reference deleted records
-      void utils.links.map.invalidate(); // Link maps may reference deleted records
-    },
-    onError: (err, _ids, ctx) => {
-      ctx?.previousRecords.forEach((data, id) => {
-        qc.setQueryData(utils.records.get.queryOptions({ id }).queryKey, data);
-      });
-      ctx?.previousLists.forEach(([key, data]) => {
-        qc.setQueryData(key, data);
-      });
-      toast.error(err instanceof Error ? err.message : 'Failed to delete records');
-    },
-  });
+      },
+    })
+  );
 }
 
 export function useMergeRecords() {
-  const qc = useQueryClient();
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const undoMergeMutation = useUndoMerge();
 
-  return trpc.records.merge.useMutation({
-    onMutate: ({ sourceId, targetId }) => {
-      // Fire cancellations but don't await - keeps onMutate synchronous
-      void utils.records.get.cancel({ id: sourceId });
-      void utils.records.get.cancel({ id: targetId });
+  return useMutation(
+    trpc.records.merge.mutationOptions({
+      onMutate: ({ sourceId, targetId }) => {
+        // Fire cancellations but don't await - keeps onMutate synchronous
+        void queryClient.cancelQueries(trpc.records.get.queryFilter({ id: sourceId }));
+        void queryClient.cancelQueries(trpc.records.get.queryFilter({ id: targetId }));
 
-      // Snapshot the previous values
-      const previousSource = utils.records.get.getData({ id: sourceId });
-      const previousTarget = utils.records.get.getData({ id: targetId });
+        // Snapshot the previous values
+        const previousSource = queryClient.getQueryData(
+          trpc.records.get.queryKey({ id: sourceId })
+        );
+        const previousTarget = queryClient.getQueryData(
+          trpc.records.get.queryKey({ id: targetId })
+        );
 
-      // Optimistically merge the records if both exist
-      if (previousSource && previousTarget) {
-        const mergedData = mergeRecords(previousSource, previousTarget);
-        const allMedia = Array.from(
-          new Set([...(previousSource.media ?? []), ...(previousTarget.media ?? [])])
-        ).map((media) => ({
-          ...media,
-          recordId: targetId,
-        }));
-        const optimisticUpdate = { ...previousTarget, ...mergedData, media: allMedia };
+        // Optimistically merge the records if both exist
+        if (previousSource && previousTarget) {
+          const mergedData = mergeRecords(previousSource, previousTarget);
+          const allMedia = Array.from(
+            new Set([...(previousSource.media ?? []), ...(previousTarget.media ?? [])])
+          ).map((media) => ({
+            ...media,
+            recordId: targetId,
+          }));
+          const optimisticUpdate = { ...previousTarget, ...mergedData, media: allMedia };
 
-        // Update the target record with merged data
-        utils.records.get.setData({ id: targetId }, optimisticUpdate);
+          // Update the target record with merged data
+          queryClient.setQueryData(trpc.records.get.queryKey({ id: targetId }), optimisticUpdate);
 
-        // Remove the source record from cache
-        const sourceKey = utils.records.get.queryOptions({ id: sourceId }).queryKey;
-        qc.setQueryData(sourceKey, () => undefined);
-      }
+          // Remove the source record from cache
+          queryClient.setQueryData(trpc.records.get.queryKey({ id: sourceId }), () => undefined);
+        }
 
-      // Optimistically remove source record from all record lists
-      const removeFromLists = (queryKey: readonly unknown[]) => {
-        const entries = qc.getQueriesData<IdParamList>({ queryKey });
+        // Optimistically remove source record from all record lists
+        const entries = queryClient.getQueriesData<IdParamList>(trpc.records.list.pathFilter());
         entries.forEach(([key, data]) => {
           if (!data) return;
-          qc.setQueryData(key, { ...data, ids: data.ids.filter(({ id }) => id !== sourceId) });
+          queryClient.setQueryData(key, {
+            ...data,
+            ids: data.ids.filter(({ id }) => id !== sourceId),
+          });
         });
-        return entries.map(([key, data]) => [key, data] as const);
-      };
 
-      const previousLists = removeFromLists(getQueryKey(trpc.records.list, undefined, 'query'));
+        return { previousSource, previousTarget, previousLists: entries };
+      },
+      onSuccess: ({ updatedRecord, deletedRecordId, touchedIds, snapshot }) => {
+        replaceBasketId(deletedRecordId, updatedRecord.id);
 
-      return { previousSource, previousTarget, previousLists };
-    },
-    onSuccess: ({ updatedRecord, deletedRecordId, touchedIds, snapshot }) => {
-      replaceBasketId(deletedRecordId, updatedRecord.id);
+        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: updatedRecord.id }));
+        void queryClient.invalidateQueries(
+          trpc.search.byRecordId.queryFilter({ id: updatedRecord.id })
+        );
 
-      void utils.records.get.invalidate({ id: updatedRecord.id });
-      void utils.search.byRecordId.invalidate({ id: updatedRecord.id });
-      void utils.records.tree.invalidate();
+        /* freeze the deleted ID so nothing refetches it */
+        const deletedKey = trpc.records.get.queryKey({ id: deletedRecordId });
 
-      /* freeze the deleted ID so nothing refetches it */
-      const deletedKey = utils.records.get.queryOptions({ id: deletedRecordId }).queryKey;
+        // stop any in-flight request
+        void queryClient.cancelQueries({ queryKey: deletedKey, exact: true });
 
-      // stop any in-flight request
-      void qc.cancelQueries({ queryKey: deletedKey, exact: true });
+        // mark as permanently gone
+        queryClient.setQueryData(deletedKey, () => undefined);
+        queryClient.setQueryDefaults(deletedKey, { staleTime: Infinity, retry: false });
 
-      // mark as permanently gone
-      qc.setQueryData(deletedKey, () => undefined);
-      qc.setQueryDefaults(deletedKey, { staleTime: Infinity, retry: false });
+        /* per-record link lists */
+        touchedIds.forEach(
+          (id) => void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id }))
+        );
 
-      /* per-record link lists */
-      touchedIds.forEach((id) => void utils.links.listForRecord.invalidate({ id }));
+        /* maps that may reference the merged records */
+        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
 
-      /* maps that overlap */
-      const touched = new Set(touchedIds);
-      void utils.links.map.invalidate(undefined, {
-        predicate: (q) => {
-          const recIds = Array.isArray(q.queryKey[1]?.input?.recordIds)
-            ? q.queryKey[1].input.recordIds
-            : undefined;
-          return !!recIds?.some((id) => touched.has(id as DbId));
-        },
-      });
+        /* record-ID tables */
+        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
+        void queryClient.invalidateQueries(trpc.records.tree.pathFilter());
 
-      /* record-ID tables */
-      void utils.records.list.invalidate();
-      void utils.records.tree.invalidate();
-
-      /* undo toast */
-      toast('Records merged', {
-        action: {
-          label: 'Undo',
-          onClick: () => undoMergeMutation.mutate({ snapshot }),
-        },
-        duration: 15_000,
-      });
-    },
-    onError: (err, vars, ctx) => {
-      // Revert optimistic updates
-      if (ctx?.previousSource) {
-        utils.records.get.setData({ id: vars.sourceId }, ctx.previousSource);
-      }
-      if (ctx?.previousTarget) {
-        utils.records.get.setData({ id: vars.targetId }, ctx.previousTarget);
-      }
-      // Restore record lists
-      ctx?.previousLists.forEach(([key, data]) => {
-        qc.setQueryData(key, data);
-      });
-      toast.error(err instanceof Error ? err.message : 'Failed to merge records');
-    },
-  });
+        /* undo toast */
+        toast('Records merged', {
+          action: {
+            label: 'Undo',
+            onClick: () => {
+              undoMergeMutation.mutate({ snapshot });
+            },
+          },
+          duration: 15_000,
+        });
+      },
+      onError: (_err, vars, ctx) => {
+        // Revert optimistic updates
+        if (ctx?.previousSource) {
+          queryClient.setQueryData(
+            trpc.records.get.queryKey({ id: vars.sourceId }),
+            ctx.previousSource
+          );
+        }
+        if (ctx?.previousTarget) {
+          queryClient.setQueryData(
+            trpc.records.get.queryKey({ id: vars.targetId }),
+            ctx.previousTarget
+          );
+        }
+        // Restore record lists
+        ctx?.previousLists.forEach(([key, data]) => {
+          queryClient.setQueryData(key, data);
+        });
+      },
+    })
+  );
 }
 
 function useUndoMerge() {
-  const qc = useQueryClient();
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  return trpc.records.undoMerge.useMutation({
-    onSuccess: ({ sourceRecord, targetRecord }) => {
-      const sourceId = sourceRecord.id;
-      const targetId = targetRecord.id;
+  return useMutation(
+    trpc.records.undoMerge.mutationOptions({
+      onSuccess: ({ sourceRecord, targetRecord }) => {
+        const sourceId = sourceRecord.id;
+        const targetId = targetRecord.id;
 
-      // Remove the staleTime: Infinity freeze on the source record
-      const sourceKey = utils.records.get.queryOptions({ id: sourceId }).queryKey;
-      qc.setQueryDefaults(sourceKey, { staleTime: undefined, retry: undefined });
+        // Remove the staleTime: Infinity freeze on the source record
+        const sourceKey = trpc.records.get.queryKey({ id: sourceId });
+        queryClient.setQueryDefaults(sourceKey, { staleTime: undefined, retry: undefined });
 
-      // Invalidate caches for both records
-      void utils.records.get.invalidate({ id: sourceId });
-      void utils.records.get.invalidate({ id: targetId });
-      void utils.search.byRecordId.invalidate({ id: sourceId });
-      void utils.search.byRecordId.invalidate({ id: targetId });
-      void utils.records.list.invalidate();
-      void utils.records.tree.invalidate();
-      void utils.links.listForRecord.invalidate({ id: sourceId });
-      void utils.links.listForRecord.invalidate({ id: targetId });
-      void utils.links.map.invalidate();
+        // Invalidate caches for both records
+        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.records.get.queryFilter({ id: targetId }));
+        void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.search.byRecordId.queryFilter({ id: targetId }));
+        void queryClient.invalidateQueries(trpc.records.list.pathFilter());
+        void queryClient.invalidateQueries(trpc.records.tree.pathFilter());
+        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: sourceId }));
+        void queryClient.invalidateQueries(trpc.links.listForRecord.queryFilter({ id: targetId }));
+        void queryClient.invalidateQueries(trpc.links.map.pathFilter());
 
-      // Navigate back to the restored source record
-      void navigate({
-        to: '/records/$recordId',
-        params: { recordId: sourceId },
-      });
+        // Navigate back to the restored source record
+        void navigate({
+          to: '/records/$recordId',
+          params: { recordId: sourceId },
+        });
 
-      toast.success('Merge undone');
-    },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to undo merge');
-    },
-  });
+        toast.success('Merge undone');
+      },
+    })
+  );
 }

--- a/src/app/lib/hooks/record-mutations.ts
+++ b/src/app/lib/hooks/record-mutations.ts
@@ -5,7 +5,20 @@ import { useTRPC } from '@/app/trpc';
 import { removeManyFromBasket, replaceBasketId } from '@/lib/hooks/use-basket';
 import { mergeRecords } from '@/shared/lib/merge-records';
 import type { DbId, IdParamList } from '@/shared/types/api';
-import type { RecordGet } from '@/shared/types/domain';
+import type { RecordGet, RecordSlim } from '@/shared/types/domain';
+
+/**
+ * Drop present-but-undefined values so an optimistic spread can't clobber
+ * cached fields the mutation input doesn't actually change (the server
+ * filters undefined the same way before writing).
+ */
+function stripUndefined<T extends object>(obj: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key in obj) {
+    if (obj[key] !== undefined) result[key] = obj[key];
+  }
+  return result;
+}
 
 export function useBulkUpdate() {
   const trpc = useTRPC();
@@ -54,7 +67,8 @@ export function useUpsertRecord() {
         await queryClient.cancelQueries(trpc.records.get.queryFilter({ id: input.id }));
         const previous = queryClient.getQueryData(trpc.records.get.queryKey({ id: input.id }));
         if (previous) {
-          const changes = input as Partial<RecordGet>;
+          const { textEmbedding: _textEmbedding, ...rest } = input;
+          const changes: Partial<RecordSlim> = stripUndefined(rest);
           queryClient.setQueryData(trpc.records.get.queryKey({ id: input.id }), (p) =>
             p ? { ...p, ...changes } : p
           );

--- a/src/app/lib/hooks/record-queries.ts
+++ b/src/app/lib/hooks/record-queries.ts
@@ -1,26 +1,22 @@
 import { PREDICATES, type Predicate, type PredicateSlug } from '@hozo';
-import { useQueries } from '@tanstack/react-query';
-import { trpc } from '@/app/trpc';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/app/trpc';
 import type { DbId, ListRecordsInput } from '@/shared/types/api';
 import type { RecordGet } from '@/shared/types/domain';
 
 export function useRecord(id: DbId) {
-  return trpc.records.get.useQuery({ id });
+  const trpc = useTRPC();
+  return useQuery(trpc.records.get.queryOptions({ id }));
 }
 
-export const useRecordSuspense = (id: DbId) => {
-  return trpc.records.get.useSuspenseQuery({ id });
-};
-
 export function useRecordList(args: ListRecordsInput) {
-  const { data, ...rest } = trpc.records.list.useQuery(args);
+  const trpc = useTRPC();
+  const { data, ...rest } = useQuery(trpc.records.list.queryOptions(args));
 
   const ids = data?.ids.map((id) => id.id) ?? [];
 
-  const utils = trpc.useUtils();
-
   const recordQueries = useQueries({
-    queries: ids.map((id) => utils.records.get.queryOptions({ id })),
+    queries: ids.map((id) => trpc.records.get.queryOptions({ id })),
   });
 
   const records = recordQueries.map((q) => q.data).filter((r) => r !== undefined);
@@ -29,15 +25,20 @@ export function useRecordList(args: ListRecordsInput) {
 }
 
 export function useRecordTree(id: DbId) {
-  return trpc.records.tree.useQuery({ id }, { placeholderData: (previousData) => previousData });
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.records.tree.queryOptions({ id }, { placeholderData: (previousData) => previousData })
+  );
 }
 
 export function useRecordLinks(id: DbId) {
-  return trpc.links.listForRecord.useQuery({ id });
+  const trpc = useTRPC();
+  return useQuery(trpc.links.listForRecord.queryOptions({ id }));
 }
 
 export function useLinksMap(ids: DbId[]) {
-  return trpc.links.map.useQuery({ recordIds: ids });
+  const trpc = useTRPC();
+  return useQuery(trpc.links.map.queryOptions({ recordIds: ids }));
 }
 
 /** Returns predicates keyed by slug (static data, no network request) */

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,12 +1,13 @@
 import { QueryClient } from '@tanstack/react-query';
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
 import { routerWithQueryClient } from '@tanstack/react-router-with-query';
-import { createServerSideHelpers } from '@trpc/react-query/server';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
 import { deserialize, serialize } from 'superjson';
+import type { AppRouter } from '@/server/api/root';
 import { DefaultCatchBoundary } from './routes/-app-components/catch-boundary';
 import { NotFound } from './routes/-app-components/not-found';
 import { routeTree } from './routeTree.gen';
-import { trpc, trpcClient } from './trpc';
+import { TRPCProvider, trpcClient } from './trpc';
 
 export function getRouter() {
   const queryClient = new QueryClient({
@@ -25,23 +26,24 @@ export function getRouter() {
     },
   });
 
-  const serverHelpers = createServerSideHelpers({
+  const trpc = createTRPCOptionsProxy<AppRouter>({
     client: trpcClient,
+    queryClient,
   });
 
   return routerWithQueryClient(
     createTanStackRouter({
       routeTree,
-      context: { queryClient, trpc: serverHelpers },
+      context: { queryClient, trpc },
       defaultPreload: 'intent',
       scrollRestoration: true,
       defaultErrorComponent: DefaultCatchBoundary,
       defaultNotFoundComponent: () => <NotFound />,
       Wrap: (props) => {
         return (
-          <trpc.Provider client={trpcClient} queryClient={queryClient}>
+          <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
             {props.children}
-          </trpc.Provider>
+          </TRPCProvider>
         );
       },
     }),

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { createRouter as createTanStackRouter } from '@tanstack/react-router';
 import { routerWithQueryClient } from '@tanstack/react-router-with-query';
 import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
@@ -10,7 +10,18 @@ import { routeTree } from './routeTree.gen';
 import { TRPCProvider, trpcClient } from './trpc';
 
 export function getRouter() {
-  const queryClient = new QueryClient({
+  // Every successful mutation invalidates all queries except those tagged
+  // `meta: { invalidation: 'manual' }`. Only active queries refetch (batched
+  // into one request by the tRPC batch link); inactive ones are marked stale.
+  // Per-mutation cache handlers narrow this default, they don't replace it.
+  const queryClient: QueryClient = new QueryClient({
+    mutationCache: new MutationCache({
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          predicate: (query) => query.meta?.invalidation !== 'manual',
+        });
+      },
+    }),
     defaultOptions: {
       dehydrate: {
         serializeData: serialize,
@@ -57,5 +68,14 @@ declare module '@tanstack/react-router' {
   }
   interface HistoryState {
     focusForm?: boolean;
+  }
+}
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: {
+      /** Opt a query out of the global invalidate-on-mutation default. */
+      invalidation?: 'manual';
+    };
   }
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -14,11 +14,15 @@ export function getRouter() {
   // `meta: { invalidation: 'manual' }`. Only active queries refetch (batched
   // into one request by the tRPC batch link); inactive ones are marked stale.
   // Per-mutation cache handlers narrow this default, they don't replace it.
+  // Data-less queries are skipped: they have nothing to go stale, and forcing
+  // a refetch on an errored query (e.g. a 404 for a deleted record) would
+  // resurface the error on every subsequent mutation.
   const queryClient: QueryClient = new QueryClient({
     mutationCache: new MutationCache({
       onSuccess: () => {
         void queryClient.invalidateQueries({
-          predicate: (query) => query.meta?.invalidation !== 'manual',
+          predicate: (query) =>
+            query.state.data !== undefined && query.meta?.invalidation !== 'manual',
         });
       },
     }),

--- a/src/app/routes/-app-components/site-search.tsx
+++ b/src/app/routes/-app-components/site-search.tsx
@@ -1,7 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
 import { PlusCircleIcon, SearchIcon } from 'lucide-react';
 import { useState } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Button } from '@/components/button';
 import { Command } from '@/components/command';
 import { Popover } from '@/components/popover';
@@ -16,6 +17,7 @@ import { SearchResultItem } from '../records/-components/search-result-item';
 const MIN_QUERY_LENGTH = 2;
 
 export const SiteSearch = () => {
+  const trpc = useTRPC();
   const navigate = useNavigate();
   const searchQ = useRouterState({
     select: (s) => (s.location.pathname === '/search' ? s.location.search.q : undefined),
@@ -29,13 +31,17 @@ export const SiteSearch = () => {
   const debouncedQuery = useDebounce(inputValue, 300);
   const shouldSearch = debouncedQuery.length >= MIN_QUERY_LENGTH;
 
-  const trigram = trpc.records.list.useQuery(
-    { searchQuery: debouncedQuery, strategy: 'lexical', limit: 10 },
-    { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+  const trigram = useQuery(
+    trpc.records.list.queryOptions(
+      { searchQuery: debouncedQuery, strategy: 'lexical', limit: 10 },
+      { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+    )
   );
-  const vector = trpc.records.list.useQuery(
-    { searchQuery: debouncedQuery, strategy: 'vector', limit: 10 },
-    { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+  const vector = useQuery(
+    trpc.records.list.queryOptions(
+      { searchQuery: debouncedQuery, strategy: 'vector', limit: 10 },
+      { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+    )
   );
 
   const trigramResults = trigram.data?.ids ?? [];

--- a/src/app/routes/__root.tsx
+++ b/src/app/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   type ErrorComponentProps,
 } from '@tanstack/react-router';
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
-import type { ServerHelpers } from '@/app/trpc';
+import type { TRPCProxy } from '@/app/trpc';
 import { Toaster } from '@/components/sonner';
 import { Tooltip } from '@/components/tooltip';
 import { KeyboardShortcutProvider } from '@/lib/keyboard-shortcuts/context';
@@ -22,7 +22,7 @@ import { NotFound as NotFoundComponent } from './-app-components/not-found';
 
 export interface RouterAppContext {
   queryClient: QueryClient;
-  trpc: ServerHelpers;
+  trpc: TRPCProxy;
 }
 
 export const Route = createRootRouteWithContext<RouterAppContext>()({

--- a/src/app/routes/arena/-components/arena-controls.tsx
+++ b/src/app/routes/arena/-components/arena-controls.tsx
@@ -1,8 +1,9 @@
 import type { RecordType } from '@hozo';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { CrosshairIcon, XIcon } from 'lucide-react';
 import { useState, type ElementType } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Button } from '@/components/button';
 import { Command } from '@/components/command';
 import { Dialog } from '@/components/dialog';
@@ -125,18 +126,21 @@ export function ArenaControls({ type, focus }: { type: RecordType; focus?: DbId 
 }
 
 function FocusSearch({ type, onSelect }: { type: RecordType; onSelect: (id: DbId) => void }) {
+  const trpc = useTRPC();
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 200);
   const shouldSearch = debouncedQuery.length >= 1;
 
-  const results = trpc.records.list.useQuery(
-    {
-      searchQuery: debouncedQuery,
-      strategy: 'lexical',
-      filters: { types: [type], isCurated: true },
-      limit: 8,
-    },
-    { enabled: shouldSearch }
+  const results = useQuery(
+    trpc.records.list.queryOptions(
+      {
+        searchQuery: debouncedQuery,
+        strategy: 'lexical',
+        filters: { types: [type], isCurated: true },
+        limit: 8,
+      },
+      { enabled: shouldSearch }
+    )
   );
   const ids = results.data?.ids ?? [];
 

--- a/src/app/routes/arena/-components/arena-session.tsx
+++ b/src/app/routes/arena/-components/arena-session.tsx
@@ -1,7 +1,8 @@
 import type { RecordType } from '@hozo';
+import { useQueryClient } from '@tanstack/react-query';
 import { EqualIcon, SkipForwardIcon } from 'lucide-react';
 import { useEffect, useEffectEvent, useState, type ReactNode } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Button } from '@/components/button';
 import { Placeholder } from '@/components/placeholder';
 import { Spinner } from '@/components/spinner';
@@ -37,7 +38,8 @@ function getSession(key: string): SessionState {
 
 export function ArenaSession({ type, focus }: { type: RecordType; focus?: DbId }) {
   const sessionKey = `${type}:${focus ?? 'open'}`;
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const [pair, setPair] = useState<Matchup>(() => sessions.get(sessionKey)?.pair ?? null);
   const [loading, setLoading] = useState(() => !sessions.get(sessionKey)?.pair);
   const submit = useSubmitMatchup();
@@ -45,8 +47,13 @@ export function ArenaSession({ type, focus }: { type: RecordType; focus?: DbId }
   const loadNext = (excludeIds: DbId[]) => {
     const session = getSession(sessionKey);
     session.excludeIds = excludeIds;
-    void utils.elo.getMatchup
-      .fetch({ recordType: type, focusRecordId: focus, excludeIds }, { staleTime: 0, gcTime: 0 })
+    void queryClient
+      .fetchQuery(
+        trpc.elo.getMatchup.queryOptions(
+          { recordType: type, focusRecordId: focus, excludeIds },
+          { staleTime: 0, gcTime: 0 }
+        )
+      )
       .then((next) => {
         session.pair = next;
         setPair(next);

--- a/src/app/routes/records/$recordId.tsx
+++ b/src/app/routes/records/$recordId.tsx
@@ -1,7 +1,8 @@
 import { isStructuralContainment, type PredicateSlug } from '@hozo';
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Card } from '@/components/card';
 import { Spinner } from '@/components/spinner';
 import { useBulkUpdate, useDeleteRecords } from '@/lib/hooks/record-mutations';
@@ -187,11 +188,14 @@ const getPreviousRecord = (ids: DbId[], currentId: DbId, skip: Set<DbId>): DbId 
 };
 
 function RouteComponent() {
+  const trpc = useTRPC();
   const navigate = Route.useNavigate();
   const { state: filtersState } = useRecordFilters();
-  const { data: recordsList } = trpc.records.list.useQuery(
-    { ...filtersState, offset: 0 },
-    { placeholderData: (prev) => prev }
+  const { data: recordsList } = useQuery(
+    trpc.records.list.queryOptions(
+      { ...filtersState, offset: 0 },
+      { placeholderData: (prev) => prev }
+    )
   );
   const { recordId } = Route.useParams();
   const { data: tree, isError: treeError, isLoading: treeLoading } = useRecordTree(recordId);

--- a/src/app/routes/records/-components/form.tsx
+++ b/src/app/routes/records/-components/form.tsx
@@ -64,6 +64,7 @@ const defaultData: RecordGet = {
   isCurated: false,
   isPrivate: false,
   eloScore: 1200,
+  matchupCount: 0,
   reminderAt: null,
   sources: [],
   media: [],

--- a/src/app/routes/records/-components/predicate-order.ts
+++ b/src/app/routes/records/-components/predicate-order.ts
@@ -1,0 +1,13 @@
+import type { PredicateType } from '@hozo';
+import { exhaustive } from '@/shared/lib/type-utils';
+
+/** Predicate types in display priority order (first = highest priority) */
+export const PREDICATE_TYPE_ORDER = exhaustive<PredicateType>()([
+  'identity',
+  'containment',
+  'creation',
+  'reference',
+  'association',
+  'form',
+  'description',
+]);

--- a/src/app/routes/records/-components/rank.tsx
+++ b/src/app/routes/records/-components/rank.tsx
@@ -65,6 +65,8 @@ export const RankSection = ({ id }: { id: DbId }) => {
         staleTime: Infinity,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
+        // Random roll: auto-invalidation would re-roll opponents on every mutation.
+        meta: { invalidation: 'manual' },
       }
     )
   );

--- a/src/app/routes/records/-components/rank.tsx
+++ b/src/app/routes/records/-components/rank.tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
   ChevronDownIcon,
@@ -9,7 +10,7 @@ import {
   ThumbsUpIcon,
 } from 'lucide-react';
 import { useEffect, useEffectEvent, useState, useSyncExternalStore } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Button } from '@/components/button';
 import { Spinner } from '@/components/spinner';
 import { Tooltip } from '@/components/tooltip';
@@ -45,7 +46,8 @@ export const RankSection = ({ id }: { id: DbId }) => {
     collapsedStore.getSnapshot,
     collapsedStore.getServerSnapshot
   );
-  const utils = trpc.useUtils();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const submit = useSubmitMatchup();
 
   // Only root-level artifacts are rankable: one contained by a parent record
@@ -55,29 +57,32 @@ export const RankSection = ({ id }: { id: DbId }) => {
     record?.type === 'artifact' &&
     (record.outgoingLinks?.some((link) => link.predicate === 'contained_by') ?? false);
   const eligible = record?.isCurated === true && !isChildArtifact;
-  const opponents = trpc.elo.getOpponents.useQuery(
-    { recordId: id, count: OPPONENT_COUNT },
-    {
-      enabled: eligible && !collapsed,
-      staleTime: Infinity,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-    }
+  const opponents = useQuery(
+    trpc.elo.getOpponents.queryOptions(
+      { recordId: id, count: OPPONENT_COUNT },
+      {
+        enabled: eligible && !collapsed,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      }
+    )
   );
 
   // Slots override the query result so a resolved opponent can be swapped out
   // without re-rolling the other rows; `seen` keeps replacements fresh.
   const [slots, setSlots] = useState<DbId[] | null>(null);
   const [seen, setSeen] = useState<DbId[]>([]);
-  const [matchupsPlayed, setMatchupsPlayed] = useState(0);
   const [reveal, setReveal] = useState<Reveal | null>(null);
   const displayed = slots ?? opponents.data?.opponentIds ?? [];
 
   const replaceOpponent = (opponentId: DbId) => {
     const excluded = [...new Set([...seen, ...displayed])];
     setSeen(excluded);
-    void utils.elo.getOpponents
-      .fetch({ recordId: id, count: 1, excludeIds: excluded })
+    void queryClient
+      .fetchQuery(
+        trpc.elo.getOpponents.queryOptions({ recordId: id, count: 1, excludeIds: excluded })
+      )
       .then(({ opponentIds }) => {
         const next = opponentIds[0];
         setSlots((prev) => {
@@ -93,8 +98,14 @@ export const RankSection = ({ id }: { id: DbId }) => {
     if (reveal) return;
     const excluded = [...new Set([...seen, ...displayed])];
     setSeen(excluded);
-    void utils.elo.getOpponents
-      .fetch({ recordId: id, count: OPPONENT_COUNT, excludeIds: excluded })
+    void queryClient
+      .fetchQuery(
+        trpc.elo.getOpponents.queryOptions({
+          recordId: id,
+          count: OPPONENT_COUNT,
+          excludeIds: excluded,
+        })
+      )
       .then(({ opponentIds }) => {
         if (opponentIds.length > 0) {
           setSlots(opponentIds);
@@ -116,7 +127,6 @@ export const RankSection = ({ id }: { id: DbId }) => {
           const focusResult = results.find((r) => r.id === id);
           const opponentResult = results.find((r) => r.id === opponentId);
           if (!focusResult || !opponentResult) return;
-          setMatchupsPlayed((n) => n + 1);
           setReveal({
             opponentId,
             focusDelta: focusResult.delta,
@@ -144,7 +154,6 @@ export const RankSection = ({ id }: { id: DbId }) => {
 
   if (!record || !eligible) return null;
 
-  const matchupCount = (opponents.data?.matchupCount ?? 0) + matchupsPlayed;
   const CollapseIcon = collapsed ? ChevronRightIcon : ChevronDownIcon;
 
   return (
@@ -209,7 +218,7 @@ export const RankSection = ({ id }: { id: DbId }) => {
               {record.eloScore}
             </styled.span>
             {reveal && <EloDelta delta={reveal.focusDelta} />}
-            <span>· {matchupCount} matchups</span>
+            <span>· {record.matchupCount} matchups</span>
           </styled.p>
           {opponents.isLoading ? (
             <Spinner />

--- a/src/app/routes/records/-components/record-lookup.tsx
+++ b/src/app/routes/records/-components/record-lookup.tsx
@@ -5,6 +5,7 @@ import {
   type Predicate,
   type PredicateSlug,
 } from '@hozo';
+import { skipToken, useQuery } from '@tanstack/react-query';
 import { ArrowLeftIcon, ArrowRightIcon, PlusCircleIcon } from 'lucide-react';
 import {
   createContext,
@@ -15,7 +16,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Badge } from '@/components/badge';
 import { Button, type ButtonProps } from '@/components/button';
 import { Command } from '@/components/command';
@@ -52,19 +53,24 @@ interface RecordSearchProps {
 }
 
 function RecordSearch({ onSelect }: RecordSearchProps) {
+  const trpc = useTRPC();
   const [query, setQuery] = useState('');
   const createRecordMutation = useUpsertRecord();
 
   const debouncedQuery = useDebounce(query, 200);
   const shouldSearch = debouncedQuery.length >= 1;
 
-  const trigram = trpc.records.list.useQuery(
-    { searchQuery: debouncedQuery, strategy: 'lexical', limit: 8 },
-    { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+  const trigram = useQuery(
+    trpc.records.list.queryOptions(
+      { searchQuery: debouncedQuery, strategy: 'lexical', limit: 8 },
+      { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+    )
   );
-  const vector = trpc.records.list.useQuery(
-    { searchQuery: debouncedQuery, strategy: 'vector', limit: 8 },
-    { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+  const vector = useQuery(
+    trpc.records.list.queryOptions(
+      { searchQuery: debouncedQuery, strategy: 'vector', limit: 8 },
+      { enabled: shouldSearch, trpc: { context: { skipBatch: true } } }
+    )
   );
 
   const trigramResults = trigram.data?.ids ?? [];
@@ -257,6 +263,7 @@ function RelationshipSelectorRoot({
   onComplete,
   buildActions,
 }: RelationshipSelectorRootProps) {
+  const trpc = useTRPC();
   const initialTarget = initialTargetId ?? link?.targetId ?? null;
   const [targetId, setTargetId] = useState<number | null>(initialTarget);
   const [predicate, setPredicate] = useState<PredicateSlug | null>(link?.predicate ?? null);
@@ -273,9 +280,8 @@ function RelationshipSelectorRoot({
     list.forEach((p) => map.set(p.slug, p));
     return Array.from(map.values());
   }, [incoming]);
-  const { data: targetRecord } = trpc.records.get.useQuery(
-    { id: targetId! },
-    { enabled: targetId !== null }
+  const { data: targetRecord } = useQuery(
+    trpc.records.get.queryOptions(targetId === null ? skipToken : { id: targetId })
   );
 
   // Reset unsaved state when the popover closes, unless the target is

--- a/src/app/routes/records/-components/record-metabar.tsx
+++ b/src/app/routes/records/-components/record-metabar.tsx
@@ -1,8 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { GlobeIcon, ShoppingBasketIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { AlertDialog } from '@/components/alert-dialog';
 import { Avatar } from '@/components/avatar';
 import { Button } from '@/components/button';
@@ -169,9 +170,11 @@ const AvatarSection = ({ record }: { record: RecordGet }) => {
     setLocalUrl(record.avatarUrl ?? '');
   }
 
+  const trpc = useTRPC();
   const upsertMutation = useUpsertRecord();
-  const { mutate: fetchFavicon, isPending: isFetchingFavicon } =
-    trpc.records.fetchFavicon.useMutation();
+  const { mutate: fetchFavicon, isPending: isFetchingFavicon } = useMutation(
+    trpc.records.fetchFavicon.mutationOptions()
+  );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLocalUrl(e.target.value);

--- a/src/app/routes/records/-components/records-grid.tsx
+++ b/src/app/routes/records/-components/records-grid.tsx
@@ -1,9 +1,10 @@
 import { IntegrationTypeSchema, type IntegrationType } from '@hozo/schema/operations.shared';
 import { RecordTypeSchema, type RecordType } from '@hozo/schema/records.shared';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { ChevronDownIcon, ShoppingBasketIcon } from 'lucide-react';
 import { useState } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Button } from '@/components/button';
 import { DropdownMenu } from '@/components/dropdown-menu';
 import { ExternalLink } from '@/components/external-link';
@@ -134,10 +135,10 @@ function RecordRow({ recordId }: { recordId: DbId }) {
 }
 
 export const RecordsGrid = () => {
+  const trpc = useTRPC();
   const { state, setFilters, setLimit, reset } = useRecordFilters();
-  const { data } = trpc.records.list.useQuery(
-    { ...state, offset: 0 },
-    { placeholderData: (prev) => prev }
+  const { data } = useQuery(
+    trpc.records.list.queryOptions({ ...state, offset: 0 }, { placeholderData: (prev) => prev })
   );
 
   const {

--- a/src/app/routes/records/-components/relations-preview.tsx
+++ b/src/app/routes/records/-components/relations-preview.tsx
@@ -4,8 +4,8 @@ import type { DbId } from '@/shared/types/api';
 import { css } from '@/styled-system/css';
 import { styled } from '@/styled-system/jsx';
 import type { SystemStyleObject } from '@/styled-system/types';
+import { PREDICATE_TYPE_ORDER } from './predicate-order';
 import { RecordLink } from './record-link';
-import { PREDICATE_TYPE_ORDER } from './relations';
 
 /** Cap per predicate group so heavily-linked records stay scannable */
 const MAX_PER_PREDICATE = 10;

--- a/src/app/routes/records/-components/relations.tsx
+++ b/src/app/routes/records/-components/relations.tsx
@@ -371,6 +371,9 @@ export const SimilarRecords = ({ id }: { id: DbId }) => {
             skipBatch: true,
           },
         },
+        // Vector search over embeddings that update asynchronously; link
+        // mutations invalidate it explicitly where similarity actually changes.
+        meta: { invalidation: 'manual' },
       }
     )
   );

--- a/src/app/routes/records/-components/relations.tsx
+++ b/src/app/routes/records/-components/relations.tsx
@@ -1,4 +1,4 @@
-import { PREDICATES, type PredicateType, type RecordType } from '@hozo';
+import { PREDICATES, type RecordType } from '@hozo';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
@@ -18,25 +18,14 @@ import { useDeleteLinks } from '@/lib/hooks/link-mutations';
 import { useMergeRecords } from '@/lib/hooks/record-mutations';
 import { usePredicateMap, useRecordLinks } from '@/lib/hooks/record-queries';
 import { useKeyboardShortcut } from '@/lib/keyboard-shortcuts/use-keyboard-shortcut';
-import { exhaustive } from '@/shared/lib/type-utils';
 import type { DbId } from '@/shared/types/api';
 import type { LinkPartial } from '@/shared/types/domain';
 import { css } from '@/styled-system/css';
 import { styled } from '@/styled-system/jsx';
+import { PREDICATE_TYPE_ORDER } from './predicate-order';
 import { RecordLink } from './record-link';
 import { RelationshipSelector } from './record-lookup';
 import { recordTypeIcons } from './type-icons';
-
-/** Predicate types in display priority order (first = highest priority) */
-export const PREDICATE_TYPE_ORDER = exhaustive<PredicateType>()([
-  'identity',
-  'containment',
-  'creation',
-  'reference',
-  'association',
-  'form',
-  'description',
-]);
 
 interface RelationsListProps {
   id: DbId;

--- a/src/app/routes/records/-components/relations.tsx
+++ b/src/app/routes/records/-components/relations.tsx
@@ -1,4 +1,5 @@
 import { PREDICATES, type PredicateType, type RecordType } from '@hozo';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import {
   ArrowLeftIcon,
@@ -9,7 +10,7 @@ import {
   TrashIcon,
 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState, type ElementType } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Spinner } from '@/components/spinner';
 import { ToggleGroup } from '@/components/toggle-group';
 import { Tooltip } from '@/components/tooltip';
@@ -361,25 +362,28 @@ const SimilarTypeShortcut = ({
 };
 
 export const SimilarRecords = ({ id }: { id: DbId }) => {
+  const trpc = useTRPC();
   const navigate = useNavigate();
   const mergeRecordsMutation = useMergeRecords();
   const [typeFilter, setTypeFilter] = useState<SimilarTypeFilter>('all');
 
   // Fetch similar records only if textEmbedding exists. Filtering by type happens in the query
   // so each type returns its own best matches rather than whatever survives the global top-N.
-  const { data: similarRecords, isLoading } = trpc.search.byRecordId.useQuery(
-    {
-      id,
-      limit: 20,
-      type: typeFilter === 'all' ? undefined : typeFilter,
-    },
-    {
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
+  const { data: similarRecords, isLoading } = useQuery(
+    trpc.search.byRecordId.queryOptions(
+      {
+        id,
+        limit: 20,
+        type: typeFilter === 'all' ? undefined : typeFilter,
       },
-    }
+      {
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+      }
+    )
   );
 
   const handleTypeFilterChange = (value: SimilarTypeFilter[]) => {

--- a/src/app/routes/records/route.tsx
+++ b/src/app/routes/records/route.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, Outlet, useMatches } from '@tanstack/react-router';
 import { useCallback } from 'react';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { RadioCards, RadioCardsItem } from '@/components/radio-cards';
 import { useRecordFilters } from '@/lib/hooks/use-record-filters';
 import { useKeyboardShortcut } from '@/lib/keyboard-shortcuts/use-keyboard-shortcut';
@@ -14,11 +15,14 @@ export const Route = createFileRoute('/records')({
 });
 
 function RouteComponent() {
+  const trpc = useTRPC();
   const navigate = Route.useNavigate();
   const { state: filtersState } = useRecordFilters();
-  const { data: recordsList } = trpc.records.list.useQuery(
-    { ...filtersState, offset: 0 },
-    { placeholderData: (prev) => prev }
+  const { data: recordsList } = useQuery(
+    trpc.records.list.queryOptions(
+      { ...filtersState, offset: 0 },
+      { placeholderData: (prev) => prev }
+    )
   );
   const matches = useMatches();
 

--- a/src/app/routes/search.tsx
+++ b/src/app/routes/search.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
-import { trpc } from '@/app/trpc';
+import { useTRPC } from '@/app/trpc';
 import { Masonry } from '@/components/masonry';
 import { Placeholder } from '@/components/placeholder';
 import { Spinner } from '@/components/spinner';
@@ -13,10 +14,13 @@ export const Route = createFileRoute('/search')({
 });
 
 function SearchPage() {
+  const trpc = useTRPC();
   const { q } = Route.useSearch();
-  const { data } = trpc.records.list.useQuery(
-    { searchQuery: q || undefined, limit: 100 },
-    { enabled: q.length > 0, placeholderData: (prev) => prev }
+  const { data } = useQuery(
+    trpc.records.list.queryOptions(
+      { searchQuery: q || undefined, limit: 100 },
+      { enabled: q.length > 0, placeholderData: (prev) => prev }
+    )
   );
 
   return (

--- a/src/app/trpc.ts
+++ b/src/app/trpc.ts
@@ -1,4 +1,5 @@
 import {
+  createTRPCClient,
   httpBatchLink,
   httpLink,
   loggerLink,
@@ -6,17 +7,16 @@ import {
   TRPCClientError,
   type TRPCLink,
 } from '@trpc/client';
-import { createTRPCReact } from '@trpc/react-query';
-import { type createServerSideHelpers } from '@trpc/react-query/server';
 import { observable } from '@trpc/server/observable';
+import { createTRPCContext, type TRPCOptionsProxy } from '@trpc/tanstack-react-query';
 import { toast } from 'sonner';
 import superjson from 'superjson';
 import type { AppRouter } from '@/server/api/root';
 import { PortSchema } from '@/shared/lib/env';
 
-export const trpc = createTRPCReact<AppRouter>();
+export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>();
 
-export type ServerHelpers = ReturnType<typeof createServerSideHelpers<AppRouter>>;
+export type TRPCProxy = TRPCOptionsProxy<AppRouter>;
 
 function getBaseUrl() {
   // 1. Running in the browser (dev or prod)
@@ -82,7 +82,7 @@ const toastLink: TRPCLink<AppRouter> = () => {
 
 const ENABLE_LOGGING = false;
 
-export const trpcClient = trpc.createClient({
+export const trpcClient = createTRPCClient<AppRouter>({
   links: [
     toastLink,
     loggerLink({

--- a/src/server/api/init.ts
+++ b/src/server/api/init.ts
@@ -4,6 +4,7 @@ import DataLoader from 'dataloader';
 import superjson from 'superjson';
 import { z, ZodError } from 'zod';
 import { db } from '@/server/db/connections/postgres';
+import { matchupCounts } from '@/server/lib/elo';
 import type { RecordGet } from '@/shared/types/domain';
 
 /** Predicate slugs for creation and containment types */
@@ -50,10 +51,16 @@ function createRecordLoader() {
     });
 
     const byId = new Map(rows.map((r) => [r.id, r]));
+    const counts = await matchupCounts(
+      db,
+      rows.map((r) => r.id)
+    );
 
     return ids.map((id) => {
       const record = byId.get(id);
-      return record ? record : new Error(`Record not found for ID: ${id}`);
+      return record
+        ? { ...record, matchupCount: counts.get(id) ?? 0 }
+        : new Error(`Record not found for ID: ${id}`);
     });
   });
 }

--- a/src/server/api/routers/elo.ts
+++ b/src/server/api/routers/elo.ts
@@ -1,8 +1,7 @@
 import { eloMatchups, records, type RecordType } from '@hozo';
 import { TRPCError } from '@trpc/server';
-import { count, eq, inArray, sql } from 'drizzle-orm';
-import type { Db } from '@/server/db/connections/postgres';
-import { eloDeltas } from '@/server/lib/elo';
+import { eq, sql } from 'drizzle-orm';
+import { eloDeltas, matchupCounts, type Queryable } from '@/server/lib/elo';
 import {
   GetMatchupInputSchema,
   GetOpponentsInputSchema,
@@ -11,33 +10,10 @@ import {
 } from '@/shared/types/api';
 import { createTRPCRouter, publicProcedure } from '../init';
 
-type Queryable = Db | Parameters<Parameters<Db['transaction']>[0]>[0];
-
 const OPPONENT_WINDOWS = [200, 400, 800, 1600, Infinity];
 const WILDCARD_PROBABILITY = 0.15;
 /** A record with fewer matchups than this gets anchored against established opponents. */
 const PROVISIONAL_MATCHUPS = 10;
-
-async function matchupCounts(db: Queryable, ids: DbId[]): Promise<Map<DbId, number>> {
-  if (ids.length === 0) return new Map();
-  const [asA, asB] = await Promise.all([
-    db
-      .select({ id: eloMatchups.recordAId, n: count() })
-      .from(eloMatchups)
-      .where(inArray(eloMatchups.recordAId, ids))
-      .groupBy(eloMatchups.recordAId),
-    db
-      .select({ id: eloMatchups.recordBId, n: count() })
-      .from(eloMatchups)
-      .where(inArray(eloMatchups.recordBId, ids))
-      .groupBy(eloMatchups.recordBId),
-  ]);
-  const counts = new Map(ids.map((id) => [id, 0]));
-  for (const { id, n } of [...asA, ...asB]) {
-    counts.set(id, (counts.get(id) ?? 0) + n);
-  }
-  return counts;
-}
 
 /**
  * The matchup pool: curated records of one type, and for artifacts only those
@@ -182,21 +158,20 @@ export const getOpponents = publicProcedure
       });
     }
 
-    const counts = await matchupCounts(db, [focus.id]);
-    const matchupCount = counts.get(focus.id) ?? 0;
-    if (!focus.isCurated) return { matchupCount, opponentIds: [] };
+    if (!focus.isCurated) return { opponentIds: [] };
     if (focus.type === 'artifact' && (await containedIds(db, [focus.id])).size > 0) {
-      return { matchupCount, opponentIds: [] };
+      return { opponentIds: [] };
     }
 
+    const counts = await matchupCounts(db, [focus.id]);
     const opponentIds = await selectOpponents(db, {
       type: focus.type,
       anchorElo: focus.eloScore,
       excludeIds: [focus.id, ...input.excludeIds],
       needed: input.count,
-      biasEstablished: matchupCount < PROVISIONAL_MATCHUPS,
+      biasEstablished: (counts.get(focus.id) ?? 0) < PROVISIONAL_MATCHUPS,
     });
-    return { matchupCount, opponentIds };
+    return { opponentIds };
   });
 
 export const getMatchup = publicProcedure

--- a/src/server/lib/elo.ts
+++ b/src/server/lib/elo.ts
@@ -1,3 +1,32 @@
+import { eloMatchups } from '@hozo';
+import { count, inArray } from 'drizzle-orm';
+import type { Db } from '@/server/db/connections/postgres';
+import type { DbId } from '@/shared/types/api';
+
+export type Queryable = Db | Parameters<Parameters<Db['transaction']>[0]>[0];
+
+/** Total matchups played per record, counting appearances on either side. */
+export async function matchupCounts(db: Queryable, ids: DbId[]): Promise<Map<DbId, number>> {
+  if (ids.length === 0) return new Map();
+  const [asA, asB] = await Promise.all([
+    db
+      .select({ id: eloMatchups.recordAId, n: count() })
+      .from(eloMatchups)
+      .where(inArray(eloMatchups.recordAId, ids))
+      .groupBy(eloMatchups.recordAId),
+    db
+      .select({ id: eloMatchups.recordBId, n: count() })
+      .from(eloMatchups)
+      .where(inArray(eloMatchups.recordBId, ids))
+      .groupBy(eloMatchups.recordBId),
+  ]);
+  const counts = new Map(ids.map((id) => [id, 0]));
+  for (const { id, n } of [...asA, ...asB]) {
+    counts.set(id, (counts.get(id) ?? 0) + n);
+  }
+  return counts;
+}
+
 /**
  * Creation-time ELO seed from an external 0-3 star signal. No signal enters at
  * the 1200 default — absence of signal is not a negative signal.

--- a/src/shared/lib/merge-records.ts
+++ b/src/shared/lib/merge-records.ts
@@ -1,5 +1,4 @@
-import type { RecordSelect } from '@hozo';
-import type { RecordGet } from '@/shared/types/domain';
+import type { RecordSlim } from '@/shared/types/domain';
 
 /**
  * Helper function to merge text fields during record merging.
@@ -57,7 +56,7 @@ function getMostRecentDate(date1: Date | null, date2: Date | null): Date | null 
  * @param target The target record (will survive the merge)
  * @returns Merged record data based on the merge rules
  */
-export function mergeRecords<T extends RecordSelect | RecordGet>(
+export function mergeRecords<T extends RecordSlim>(
   source: T,
   target: T
 ): Omit<T, 'id'> & { recordUpdatedAt: Date; textEmbedding: null } {

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -5,11 +5,13 @@ import type { DbId } from './api';
  * Core domain types used across client and server
  */
 
-// Record without embedding or search-index data (for client consumption)
-export type RecordGet = Omit<
-  RecordSelect & { media?: MediaSelect[] },
-  'textEmbedding' | 'textSearch'
-> & {
+// Record row without embedding or search-index data
+export type RecordSlim = Omit<RecordSelect, 'textEmbedding' | 'textSearch'>;
+
+// records.get response: slim record enriched with API-computed data
+export type RecordGet = RecordSlim & {
+  matchupCount: number;
+  media?: MediaSelect[];
   outgoingLinks?: Array<{
     predicate: PredicateSlug;
     target: { id: DbId; title: string | null };
@@ -18,8 +20,8 @@ export type RecordGet = Omit<
 
 // Complete record with both incoming and outgoing links
 export interface FullRecord extends RecordSelect {
-  outgoingLinks: Array<LinkSelect & { target: RecordGet }>;
-  incomingLinks: Array<LinkSelect & { source: RecordGet }>;
+  outgoingLinks: Array<LinkSelect & { target: RecordSlim }>;
+  incomingLinks: Array<LinkSelect & { source: RecordSlim }>;
   media: Array<MediaSelect>;
 }
 


### PR DESCRIPTION
Playing arena matchups and returning to the record showed a stale matchup count until a hard refresh. The count came from `elo.getOpponents`, which is cached with `staleTime: Infinity` and never invalidated after `submitMatchup`; the rank section compensated with local state that reset on navigation. The count now lives on the record itself: the record loader attaches an authoritative `matchupCount` to `records.get`, `submitMatchup` patches the participants' cached records from the mutation response, and `getOpponents` no longer returns data that can go stale.

Alongside the fix, moves from the classic `createTRPCReact` integration to tRPC's recommended TanStack-native client (`@trpc/tanstack-react-query`). Queries and mutations use the native hooks with typed `queryOptions`/`mutationOptions` factories, and cache updates go through the query client with typed `queryKey()`/`queryFilter()`/`pathFilter()` helpers instead of `useUtils`. Route loaders already consumed `queryOptions` from the server-side helpers, so they carry over unchanged against the options proxy in router context.

The stale-count bug was one instance of a broader failure mode: every mutation maintained its own hand-rolled invalidation list, and any query missed by every list served stale data forever. Cache freshness is now a global default rather than per-mutation bookkeeping: a `MutationCache.onSuccess` handler invalidates everything after any successful mutation (active queries refetch in one batched request; inactive ones are marked stale), and the two queries that must not auto-refetch — `elo.getOpponents`, which would re-roll the opponent list mid-session, and `search.byRecordId`, whose embeddings update asynchronously — opt out with `meta: { invalidation: 'manual' }`. Mutation handlers keep only optimistic updates and response patching.

Deletions and merges need their dead record kept out of the global refetch, and the existing merge cleanup turned out to be a no-op: `setQueryData` with an updater returning `undefined` bails out in TanStack Query v5, so the "remove source from cache" writes never touched the cache. Merge now drops the source record's point queries in `onMutate`, exactly as delete does — removed queries are invisible to `invalidateQueries` — and the global predicate skips data-less queries so an errored 404 entry isn't re-refetched by every subsequent mutation.

The typed key helpers surfaced a few problems the old client let slide:

- The delete-link optimistic update filtered on a malformed raw query key that never matched real tRPC keys, so deleted links never disappeared optimistically.
- The `links.map` invalidations spelunked through untyped query-key internals to skip unaffected maps; they now invalidate the whole path, which only refetches active queries.
- The record-lookup target query drops its non-null assertion in favor of `skipToken`.
- The upsert optimistic patch cast its input to the cached record shape; a typed `stripUndefined` helper replaces the cast so schema drift between mutation input and cache fails to compile.

Also: removes duplicate error toasts in mutation `onError` handlers (the global toast link already reports every error), replaces the `-Date.now()` optimistic link id with a module counter that cannot collide on rapid creates, moves `PREDICATE_TYPE_ORDER` to its own module to restore Fast Refresh, and deletes the unused `useRecordSuspense` hook.