### PR TITLE
Document ZERO_ADMIN_PASSWORD and prune the sync-engine enablement runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ ZERO_APP_PUBLICATIONS="zero_data"
 ZERO_QUERY_URL="http://localhost:5173/api/zero/query"
 ZERO_MUTATE_URL="http://localhost:5173/api/zero/mutate"
 ZERO_LOG_LEVEL="info"
+# Required when NODE_ENV=production; zero-cache refuses to start without it
+ZERO_ADMIN_PASSWORD="[random-secret]"
 # Reached by the browser, so it must resolve for clients, not just the server
 PUBLIC_ZERO_CACHE_URL="http://localhost:4848"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -52,29 +52,13 @@ This creates the production build in the `dist/` directory.
 The `ecosystem.config.cjs` file in the root directory manages:
 
 - **red-cliff-record**: The main application (runs on `bun run server.ts`)
-- **red-cliff-zero-cache**: The Zero sync engine, which replicates the entity graph to clients. The app cannot load data without it; see "Enabling the sync engine on an existing deployment" below for the prerequisites
+- **red-cliff-zero-cache**: The Zero sync engine, which replicates the entity graph to clients. The app cannot load data without it; database prerequisites (`wal_level`, publication, `ZERO_*` variables) are in the main `README.md` → Zero Sync Engine
 - **red-cliff-deploy**: The auto-deployment monitor that checks for updates every 60 seconds
 
-### Enabling the sync engine on an existing deployment
-
-A deployment that predates the sync engine will not pick it up from a `git pull` alone — two of the moving parts sit outside the auto-deploy loop:
+Two of the moving parts sit outside the auto-deploy loop:
 
 - The monitor holds its loaded copy of `auto-deploy.sh` in memory, so edits to the script (new deploy steps included) take effect only after `pm2 restart red-cliff-deploy`.
-- `pm2 restart` only touches processes pm2 already knows about, so apps added to `ecosystem.config.cjs` must be registered with `pm2 start ecosystem.config.cjs`.
-
-Once per box, after pulling a revision that includes the sync engine:
-
-1. Set `wal_level = logical` on the upstream Postgres and restart it:
-
-   ```bash
-   psql $DATABASE_URL -c "ALTER SYSTEM SET wal_level = 'logical';"
-   ```
-
-2. Add the `ZERO_*` and `PUBLIC_ZERO_CACHE_URL` variables to `.env` (see `.env.example` — the query/mutate/cache URLs must use the deployed origin, not localhost).
-3. Create the `zero_data` publication: `NODE_ENV=production bun run zero:publication`
-4. Register the new processes, refresh the monitor, and persist: `pm2 start ecosystem.config.cjs && pm2 restart red-cliff-deploy && pm2 save`
-
-Deploys after that are fully automatic: the loop re-syncs the publication after migrations and restarts both the app and zero-cache.
+- `pm2 restart` only touches processes pm2 already knows about, so apps added to `ecosystem.config.cjs` must be registered with `pm2 start ecosystem.config.cjs`, then persisted with `pm2 save`.
 
 ### Logging
 


### PR DESCRIPTION
Enabling the sync engine in production surfaced a gap: zero-cache refuses to start when `NODE_ENV=production` without `ZERO_ADMIN_PASSWORD`, and `.env.example` never mentioned the variable. Adds it with a note on when it's required.

Also removes the "Enabling the sync engine on an existing deployment" runbook from the deploy README — it covered the one-time transition for a box that predates the sync engine, which has been completed. The durable per-database setup lives in the main README's Zero Sync Engine section, and the two pm2 behaviors worth keeping (the monitor caches its loaded script; new ecosystem apps must be registered with `pm2 start`) stay as a short note.