### PR TITLE
Add a Bradley-Terry ELO refit over the full matchup history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/server/api/routers/records/index.ts
+++ b/src/server/api/routers/records/index.ts
@@ -6,6 +6,7 @@ import { fetchFavicon } from './favicon';
 import { get } from './get';
 import { list } from './list';
 import { merge } from './merge';
+import { refitElo } from './refit-elo';
 import { getFamilyTree } from './tree';
 import { undoMerge } from './undo-merge';
 
@@ -16,6 +17,7 @@ export const recordsRouter = createTRPCRouter({
   upsert,
   bulkUpdate,
   merge,
+  refitElo,
   undoMerge,
   delete: deleteRecords,
   tree: getFamilyTree,

--- a/src/server/api/routers/records/refit-elo.ts
+++ b/src/server/api/routers/records/refit-elo.ts
@@ -1,44 +1,5 @@
-import { records } from '@hozo';
-import { sql } from 'drizzle-orm';
-import { fitBradleyTerry } from '@/shared/lib/elo';
+import { runEloRefit } from '@/server/services/refit-elo';
 import { publicProcedure } from '../../init';
 
-/**
- * Refit every ELO score from the stored matchup history with a batch
- * Bradley-Terry fit, so each recorded result informs the whole comparison
- * graph instead of just its two participants. Records without matchups keep
- * their current score. Incremental arena updates remain the live layer;
- * this recomputes from the same evidence whenever it runs.
- */
-export const refitElo = publicProcedure.mutation(async ({ ctx: { db } }) => {
-  const matchups = await db.query.eloMatchups.findMany({
-    columns: { recordAId: true, recordBId: true, winnerId: true },
-  });
-  const fitted = fitBradleyTerry(matchups);
-  if (fitted.size === 0) {
-    return { matchups: 0, ranked: 0, updated: 0 };
-  }
-  const current = await db.query.records.findMany({
-    where: { id: { in: [...fitted.keys()] } },
-    columns: { id: true, eloScore: true },
-  });
-  const changed = current.flatMap((record) => {
-    const eloScore = fitted.get(record.id);
-    return eloScore !== undefined && eloScore !== record.eloScore
-      ? [{ id: record.id, eloScore }]
-      : [];
-  });
-  if (changed.length > 0) {
-    const values = sql.join(
-      changed.map(({ id, eloScore }) => sql`(${id}::int, ${eloScore}::int)`),
-      sql`, `
-    );
-    await db.execute(sql`
-      update ${records}
-      set elo_score = fitted.elo_score
-      from (values ${values}) as fitted(id, elo_score)
-      where ${records.id} = fitted.id
-    `);
-  }
-  return { matchups: matchups.length, ranked: fitted.size, updated: changed.length };
-});
+/** Refit every ELO score from the stored matchup history. */
+export const refitElo = publicProcedure.mutation(() => runEloRefit());

--- a/src/server/api/routers/records/refit-elo.ts
+++ b/src/server/api/routers/records/refit-elo.ts
@@ -1,0 +1,44 @@
+import { records } from '@hozo';
+import { sql } from 'drizzle-orm';
+import { fitBradleyTerry } from '@/shared/lib/elo';
+import { publicProcedure } from '../../init';
+
+/**
+ * Refit every ELO score from the stored matchup history with a batch
+ * Bradley-Terry fit, so each recorded result informs the whole comparison
+ * graph instead of just its two participants. Records without matchups keep
+ * their current score. Incremental arena updates remain the live layer;
+ * this recomputes from the same evidence whenever it runs.
+ */
+export const refitElo = publicProcedure.mutation(async ({ ctx: { db } }) => {
+  const matchups = await db.query.eloMatchups.findMany({
+    columns: { recordAId: true, recordBId: true, winnerId: true },
+  });
+  const fitted = fitBradleyTerry(matchups);
+  if (fitted.size === 0) {
+    return { matchups: 0, ranked: 0, updated: 0 };
+  }
+  const current = await db.query.records.findMany({
+    where: { id: { in: [...fitted.keys()] } },
+    columns: { id: true, eloScore: true },
+  });
+  const changed = current.flatMap((record) => {
+    const eloScore = fitted.get(record.id);
+    return eloScore !== undefined && eloScore !== record.eloScore
+      ? [{ id: record.id, eloScore }]
+      : [];
+  });
+  if (changed.length > 0) {
+    const values = sql.join(
+      changed.map(({ id, eloScore }) => sql`(${id}::int, ${eloScore}::int)`),
+      sql`, `
+    );
+    await db.execute(sql`
+      update ${records}
+      set elo_score = fitted.elo_score
+      from (values ${values}) as fitted(id, elo_score)
+      where ${records.id} = fitted.id
+    `);
+  }
+  return { matchups: matchups.length, ranked: fitted.size, updated: changed.length };
+});

--- a/src/server/cli/rcr/commands/enrich.ts
+++ b/src/server/cli/rcr/commands/enrich.ts
@@ -5,11 +5,13 @@
  * - avatars: Upload external avatar URLs to R2
  * - alt-text: Generate alt text for image/video media using OpenAI vision
  * - embeddings: Generate text embeddings for records
+ * - elo: Refit ELO scores from the stored matchup history
  */
 
 import { z } from 'zod';
 import { runEmbedRecordsIntegration } from '@/server/services/embed-records';
 import { runAltTextIntegration } from '@/server/services/generate-alt-text';
+import { runEloRefit } from '@/server/services/refit-elo';
 import { runSaveAvatarsIntegration } from '@/server/services/save-avatars';
 import { assertNever } from '@/shared/lib/type-utils';
 import { BaseOptionsSchema, parseOptions } from '../lib/args';
@@ -17,7 +19,7 @@ import { createError } from '../lib/errors';
 import { success } from '../lib/output';
 import type { CommandHandler } from '../lib/types';
 
-const EnrichmentNameSchema = z.enum(['avatars', 'alt-text', 'embeddings']);
+const EnrichmentNameSchema = z.enum(['avatars', 'alt-text', 'embeddings', 'elo']);
 type EnrichmentName = z.infer<typeof EnrichmentNameSchema>;
 const ENRICHMENT_LIST = EnrichmentNameSchema.options;
 
@@ -33,8 +35,9 @@ const EnrichOptionsSchema = BaseOptionsSchema.extend({
  *   avatars     Upload external avatar URLs to R2
  *   alt-text    Generate alt text for image/video media using OpenAI vision
  *   embeddings  Generate text embeddings for records
+ *   elo         Refit ELO scores from the stored matchup history
  *
- * If no enrichment is specified, runs all three in order.
+ * If no enrichment is specified, runs all of them in order.
  *
  * Options:
  *   --limit=N   For alt-text: max media items to process (default: 100)
@@ -102,16 +105,25 @@ async function runSingleEnrichment(enrichment: EnrichmentName, options: EnrichOp
         duration: Math.round(performance.now() - startTime),
       };
     }
+    case 'elo': {
+      const result = await runEloRefit();
+      return {
+        enrichment,
+        success: true,
+        ...result,
+        duration: Math.round(performance.now() - startTime),
+      };
+    }
     default:
       assertNever(enrichment);
   }
 }
 
 /**
- * Run all enrichments in order: avatars → alt-text → embeddings
+ * Run all enrichments in order: avatars → alt-text → embeddings → elo
  */
 async function runAllEnrichments(options: EnrichOptions) {
-  const enrichments: EnrichmentName[] = ['avatars', 'alt-text', 'embeddings'];
+  const enrichments: EnrichmentName[] = ['avatars', 'alt-text', 'embeddings', 'elo'];
   const results: Array<{ enrichment: string; success: boolean; error?: string }> = [];
   const startTime = performance.now();
 

--- a/src/server/cli/rcr/commands/records.ts
+++ b/src/server/cli/rcr/commands/records.ts
@@ -339,6 +339,17 @@ export const merge: CommandHandler = async (args, options) => {
 };
 
 /**
+ * Refit all ELO scores from the stored matchup history (batch Bradley-Terry)
+ * Usage: rcr records refit-elo
+ */
+export const refitElo: CommandHandler = async (_args, options) => {
+  parseOptions(BaseOptionsSchema.strict(), options);
+  const result = await caller.records.refitElo();
+  return success(result);
+};
+export { refitElo as 'refit-elo' };
+
+/**
  * Generate embedding for record(s)
  * Usage: rcr records embed <id...>
  */

--- a/src/server/cli/rcr/index.ts
+++ b/src/server/cli/rcr/index.ts
@@ -143,6 +143,7 @@ Commands:
   records bulk-update <ids> <json>  Bulk update records by ID
   records delete <id...>        Delete record(s)
   records merge <src> <target>  Merge source record into target
+  records refit-elo             Refit all ELO scores from matchup history
   records embed <id...>         Generate embedding(s) for record(s)
   records tree <id...>          Get hierarchical family tree(s)
   records children <id>         Get children of a record

--- a/src/server/cli/rcr/index.ts
+++ b/src/server/cli/rcr/index.ts
@@ -176,10 +176,11 @@ Commands:
   sync                          Run all daily syncs + enrich
   sync <integration>            Run a single sync (github, readwise, etc.) + enrich
 
-  enrich [enrichment]           Run enrichments (avatars, alt-text, embeddings)
+  enrich [enrichment]           Run enrichments (avatars, alt-text, embeddings, elo)
   enrich avatars                Upload external avatar URLs to R2
   enrich alt-text               Generate alt text for image/video media [--limit=N]
   enrich embeddings             Generate text embeddings for records
+  enrich elo                    Refit ELO scores from matchup history
 
   db backup <prod|dev>          Backup database [--data-only] [--dry-run|-n]
   db restore <prod|dev>         Restore database [--clean] [--data-only] [--dry-run|-n]

--- a/src/server/services/refit-elo.ts
+++ b/src/server/services/refit-elo.ts
@@ -1,38 +1,124 @@
-import { records } from '@hozo';
+import { records, type RecordType } from '@hozo';
 import { sql } from 'drizzle-orm';
 import { db } from '@/server/db/connections/postgres';
-import { fitBradleyTerry } from '@/shared/lib/elo';
+import { fitBradleyTerry, relevanceToEloPriors } from '@/shared/lib/elo';
 
 export type RefitEloResult = { matchups: number; ranked: number; updated: number };
 
+/** Rows per bulk-update statement, keeping parameter counts well under the wire-protocol cap. */
+const UPDATE_BATCH_SIZE = 5000;
+
+type RecordSignals = {
+  id: number;
+  type: RecordType;
+  is_curated: boolean;
+  has_notes: boolean;
+  has_url: boolean;
+  has_summary: boolean;
+  has_content: boolean;
+  has_media_caption: boolean;
+  containment_links: string;
+  other_links: string;
+  media_count: string;
+};
+
 /**
- * Refit every ELO score from the stored matchup history with a batch
- * Bradley-Terry fit, so each recorded result informs the whole comparison
- * graph instead of just its two participants. Records without matchups keep
- * their current score. Incremental arena updates remain the live layer;
- * this recomputes from the same evidence whenever it runs.
+ * Compute a raw relevance score from richness signals: explicit curation as a
+ * multiplier over a sqrt-dampened sum that rewards breadth of metadata
+ * without letting any single signal dominate.
+ */
+function computeRelevance(s: RecordSignals): number {
+  const multiplier = 1 + (s.is_curated ? 1 : 0);
+  const richness =
+    Number(s.containment_links) + // structural hierarchy (parent/child, quotes)
+    Number(s.other_links) * 2 + // graph centrality (refs, tags, associations, creation)
+    Number(s.media_count) * 2 + // visual richness
+    (s.has_media_caption ? 4 : 0) + // curated media description
+    (s.has_notes ? 2 : 0) + // personal annotation
+    (s.has_url ? 1 : 0) + // has source
+    (s.has_summary ? 3 : 0) + // has summary
+    (s.has_content ? 4 : 0); // has substantial content
+  return multiplier * Math.sqrt(richness);
+}
+
+/**
+ * Derive a prior score for every record from its current richness signals,
+ * percentile-mapped onto the Elo scale within each record type so types with
+ * different richness profiles stay comparable.
+ */
+async function computePriors(): Promise<Map<number, number>> {
+  const rows = await db.execute<RecordSignals>(sql`
+    SELECT
+      r.id,
+      r.type,
+      r.is_curated,
+      r.notes IS NOT NULL AND r.notes != '' AS has_notes,
+      r.url IS NOT NULL AND r.url != '' AS has_url,
+      r.summary IS NOT NULL AND r.summary != '' AS has_summary,
+      r.content IS NOT NULL AND r.content != '' AS has_content,
+      r.media_caption IS NOT NULL AND r.media_caption != '' AS has_media_caption,
+      COALESCE(l.containment_cnt, 0) AS containment_links,
+      COALESCE(l.other_cnt, 0) AS other_links,
+      COALESCE(m.cnt, 0) AS media_count
+    FROM records r
+    LEFT JOIN (
+      SELECT
+        rid,
+        COUNT(*) FILTER (WHERE predicate IN ('contained_by', 'quotes')) AS containment_cnt,
+        COUNT(*) FILTER (WHERE predicate NOT IN ('contained_by', 'quotes', 'has_format')) AS other_cnt
+      FROM (
+        SELECT source_id AS rid, predicate FROM links
+        UNION ALL
+        SELECT target_id AS rid, predicate FROM links
+      ) t
+      GROUP BY rid
+    ) l ON l.rid = r.id
+    LEFT JOIN (
+      SELECT record_id AS rid, COUNT(*) AS cnt
+      FROM media WHERE record_id IS NOT NULL
+      GROUP BY record_id
+    ) m ON m.rid = r.id
+  `);
+  const byType = Map.groupBy(rows, (row) => row.type);
+  const priors = new Map<number, number>();
+  for (const group of byType.values()) {
+    const relevances = new Map(group.map((row) => [row.id, computeRelevance(row)]));
+    for (const [id, elo] of relevanceToEloPriors(relevances)) priors.set(id, elo);
+  }
+  return priors;
+}
+
+/**
+ * Refit every ELO score with a batch Bradley-Terry fit: each record gets a
+ * richness-derived prior, and the stored matchup history moves records
+ * relative to those priors, propagating each result through the whole
+ * comparison graph instead of just its two participants. Records with no
+ * matchups score exactly their prior. Incremental arena updates remain the
+ * live layer; this recomputes from the same evidence whenever it runs.
  */
 export async function runEloRefit(): Promise<RefitEloResult> {
-  const matchups = await db.query.eloMatchups.findMany({
-    columns: { recordAId: true, recordBId: true, winnerId: true },
-  });
-  const fitted = fitBradleyTerry(matchups);
+  const [matchups, priors] = await Promise.all([
+    db.query.eloMatchups.findMany({
+      columns: { recordAId: true, recordBId: true, winnerId: true },
+    }),
+    computePriors(),
+  ]);
+  const fitted = fitBradleyTerry(matchups, priors);
   if (fitted.size === 0) {
     return { matchups: 0, ranked: 0, updated: 0 };
   }
-  const current = await db.query.records.findMany({
-    where: { id: { in: [...fitted.keys()] } },
-    columns: { id: true, eloScore: true },
-  });
+  const current = await db.query.records.findMany({ columns: { id: true, eloScore: true } });
   const changed = current.flatMap((record) => {
     const eloScore = fitted.get(record.id);
     return eloScore !== undefined && eloScore !== record.eloScore
       ? [{ id: record.id, eloScore }]
       : [];
   });
-  if (changed.length > 0) {
+  for (let offset = 0; offset < changed.length; offset += UPDATE_BATCH_SIZE) {
     const values = sql.join(
-      changed.map(({ id, eloScore }) => sql`(${id}::int, ${eloScore}::int)`),
+      changed
+        .slice(offset, offset + UPDATE_BATCH_SIZE)
+        .map(({ id, eloScore }) => sql`(${id}::int, ${eloScore}::int)`),
       sql`, `
     );
     await db.execute(sql`

--- a/src/server/services/refit-elo.ts
+++ b/src/server/services/refit-elo.ts
@@ -1,0 +1,46 @@
+import { records } from '@hozo';
+import { sql } from 'drizzle-orm';
+import { db } from '@/server/db/connections/postgres';
+import { fitBradleyTerry } from '@/shared/lib/elo';
+
+export type RefitEloResult = { matchups: number; ranked: number; updated: number };
+
+/**
+ * Refit every ELO score from the stored matchup history with a batch
+ * Bradley-Terry fit, so each recorded result informs the whole comparison
+ * graph instead of just its two participants. Records without matchups keep
+ * their current score. Incremental arena updates remain the live layer;
+ * this recomputes from the same evidence whenever it runs.
+ */
+export async function runEloRefit(): Promise<RefitEloResult> {
+  const matchups = await db.query.eloMatchups.findMany({
+    columns: { recordAId: true, recordBId: true, winnerId: true },
+  });
+  const fitted = fitBradleyTerry(matchups);
+  if (fitted.size === 0) {
+    return { matchups: 0, ranked: 0, updated: 0 };
+  }
+  const current = await db.query.records.findMany({
+    where: { id: { in: [...fitted.keys()] } },
+    columns: { id: true, eloScore: true },
+  });
+  const changed = current.flatMap((record) => {
+    const eloScore = fitted.get(record.id);
+    return eloScore !== undefined && eloScore !== record.eloScore
+      ? [{ id: record.id, eloScore }]
+      : [];
+  });
+  if (changed.length > 0) {
+    const values = sql.join(
+      changed.map(({ id, eloScore }) => sql`(${id}::int, ${eloScore}::int)`),
+      sql`, `
+    );
+    await db.execute(sql`
+      update ${records}
+      set elo_score = fitted.elo_score
+      from (values ${values}) as fitted(id, elo_score)
+      where ${records.id} = fitted.id
+    `);
+  }
+  return { matchups: matchups.length, ranked: fitted.size, updated: changed.length };
+}

--- a/src/shared/lib/elo.test.ts
+++ b/src/shared/lib/elo.test.ts
@@ -4,6 +4,7 @@ import {
   expectedScore,
   fitBradleyTerry,
   kFactor,
+  relevanceToEloPriors,
   selectMatchup,
   selectOpponents,
   type MatchupOutcome,
@@ -239,5 +240,66 @@ describe('fitBradleyTerry', () => {
     const scores = fitBradleyTerry([win(1, 2), win(3, 4)]);
     expect(score(scores, 1)).toBe(score(scores, 3));
     expect(score(scores, 2)).toBe(score(scores, 4));
+  });
+
+  test('priors: a record with no matchups scores exactly its prior', () => {
+    const scores = fitBradleyTerry([win(1, 2)], new Map([[3, 1750]]));
+    expect(score(scores, 3)).toBe(1750);
+  });
+
+  test('priors: equal wins over equal opponents preserve the prior gap', () => {
+    const priors = new Map([
+      [1, 1800],
+      [2, 900],
+      [3, 1200],
+      [4, 1200],
+    ]);
+    const scores = fitBradleyTerry([win(1, 3), win(2, 4)], priors);
+    expect(score(scores, 1)).toBeGreaterThan(score(scores, 2));
+    expect(score(scores, 1)).toBeGreaterThan(1800);
+    expect(score(scores, 2)).toBeGreaterThan(900);
+  });
+
+  test('priors: beating a stronger opponent earns more', () => {
+    const priors = new Map([
+      [1, 1200],
+      [2, 1200],
+      [3, 1600],
+      [4, 1000],
+    ]);
+    const scores = fitBradleyTerry([win(1, 3), win(2, 4)], priors);
+    expect(score(scores, 1)).toBeGreaterThan(score(scores, 2));
+  });
+});
+
+describe('relevanceToEloPriors', () => {
+  test('a single record sits at the 1200 median', () => {
+    expect(relevanceToEloPriors(new Map([[1, 7]])).get(1)).toBe(1200);
+  });
+
+  test('ordering follows relevance and ties share a score', () => {
+    const priors = relevanceToEloPriors(
+      new Map([
+        [1, 10],
+        [2, 5],
+        [3, 5],
+        [4, 1],
+      ])
+    );
+    expect(priors.get(2)).toBe(priors.get(3));
+    expect(priors.get(1)).toBeGreaterThan(priors.get(2) ?? 0);
+    expect(priors.get(2)).toBeGreaterThan(priors.get(4) ?? 0);
+  });
+
+  test('percentiles map symmetrically around 1200', () => {
+    const priors = relevanceToEloPriors(
+      new Map([
+        [1, 1],
+        [2, 2],
+        [3, 3],
+      ])
+    );
+    expect(priors.get(2)).toBe(1200);
+    expect((priors.get(1) ?? 0) - 1200).toBe(1200 - (priors.get(3) ?? 0));
   });
 });

--- a/src/shared/lib/elo.test.ts
+++ b/src/shared/lib/elo.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import {
   eloDeltas,
   expectedScore,
+  fitBradleyTerry,
   kFactor,
   selectMatchup,
   selectOpponents,
+  type MatchupOutcome,
   type PoolCandidate,
 } from './elo';
 
@@ -176,5 +178,66 @@ describe('eloDeltas', () => {
     );
     expect(deltaA).toBe(16);
     expect(deltaB).toBe(-8);
+  });
+});
+
+describe('fitBradleyTerry', () => {
+  const win = (winnerId: number, loserId: number): MatchupOutcome => ({
+    recordAId: winnerId,
+    recordBId: loserId,
+    winnerId,
+  });
+  const draw = (recordAId: number, recordBId: number): MatchupOutcome => ({
+    recordAId,
+    recordBId,
+    winnerId: null,
+  });
+  const score = (scores: Map<number, number>, id: number): number => {
+    const value = scores.get(id);
+    if (value === undefined) throw new Error(`No score for record ${id}`);
+    return value;
+  };
+
+  test('empty history fits nothing', () => {
+    expect(fitBradleyTerry([]).size).toBe(0);
+  });
+
+  test('a single win places the winner symmetrically above the loser', () => {
+    const scores = fitBradleyTerry([win(1, 2)]);
+    expect(score(scores, 1)).toBeGreaterThan(1200);
+    expect(score(scores, 1) - 1200).toBe(1200 - score(scores, 2));
+  });
+
+  test('a draw leaves both records at the default score', () => {
+    const scores = fitBradleyTerry([draw(1, 2)]);
+    expect(score(scores, 1)).toBe(1200);
+    expect(score(scores, 2)).toBe(1200);
+  });
+
+  test('orders a transitive chain never directly compared end to end', () => {
+    const scores = fitBradleyTerry([win(1, 2), win(1, 2), win(2, 3), win(2, 3)]);
+    expect(score(scores, 1)).toBeGreaterThan(score(scores, 2));
+    expect(score(scores, 2)).toBeGreaterThan(score(scores, 3));
+  });
+
+  test('a result propagates to records outside the new matchup', () => {
+    const history = [win(1, 2), win(2, 3)];
+    const before = fitBradleyTerry(history);
+    const after = fitBradleyTerry([...history, win(3, 4)]);
+    // Record 3 proving strength lifts record 2 (who beat it), and record 1 in turn.
+    expect(score(after, 2)).toBeGreaterThan(score(before, 2));
+    expect(score(after, 1)).toBeGreaterThan(score(before, 1));
+  });
+
+  test('the anchor keeps an undefeated record finite', () => {
+    const scores = fitBradleyTerry(Array.from({ length: 20 }, () => win(1, 2)));
+    expect(score(scores, 1)).toBeGreaterThan(1200);
+    expect(score(scores, 1)).toBeLessThan(2400);
+  });
+
+  test('disconnected components share a common scale', () => {
+    const scores = fitBradleyTerry([win(1, 2), win(3, 4)]);
+    expect(score(scores, 1)).toBe(score(scores, 3));
+    expect(score(scores, 2)).toBe(score(scores, 4));
   });
 });

--- a/src/shared/lib/elo.ts
+++ b/src/shared/lib/elo.ts
@@ -128,24 +128,97 @@ export function eloDeltas(
 /** A stored matchup outcome; a null winner is a draw. */
 export type MatchupOutcome = { recordAId: number; recordBId: number; winnerId: number | null };
 
+const DEFAULT_ELO = 1200;
+/** Points per tenfold strength ratio on the Elo scale, matching expectedScore. */
+const ELO_SCALE = 400;
+/** Spread of the prior distribution records are percentile-mapped onto. */
+const PRIOR_SD = 150;
+
 /**
- * Pseudo-draws each record plays against a fixed 1200-rated anchor. They keep
- * undefeated records finite, shrink sparse histories toward the default score,
- * and pin disconnected regions of the comparison graph to a common scale.
+ * Pseudo-draws each record plays against a fixed anchor at its own prior
+ * score. They weight the prior against matchup evidence, keep undefeated
+ * records finite, and pin disconnected regions of the comparison graph to a
+ * common scale.
  */
 const REFIT_ANCHOR_GAMES = 2;
 const REFIT_MAX_ITERATIONS = 1000;
 const REFIT_TOLERANCE = 1e-10;
 
+const toStrength = (elo: number): number => 10 ** ((elo - DEFAULT_ELO) / ELO_SCALE);
+
+/** Inverse standard normal CDF (Acklam's approximation, |error| < 1.2e-9) on (0, 1). */
+function probit(p: number): number {
+  const pLow = 0.02425;
+  if (p < pLow || p > 1 - pLow) {
+    const q = Math.sqrt(-2 * Math.log(Math.min(p, 1 - p)));
+    const z =
+      (((((-7.784894002430293e-3 * q + -3.223964580411365e-1) * q + -2.400758277161838) * q +
+        -2.549732539343734) *
+        q +
+        4.374664141464968) *
+        q +
+        2.938163982698783) /
+      ((((7.784695709041462e-3 * q + 3.224671290700398e-1) * q + 2.445134137142996) * q +
+        3.754408661907416) *
+        q +
+        1);
+    return p < pLow ? z : -z;
+  }
+  const q = p - 0.5;
+  const r = q * q;
+  return (
+    ((((((-3.969683028665376e1 * r + 2.209460984245205e2) * r + -2.759285104469687e2) * r +
+      1.38357751867269e2) *
+      r +
+      -3.066479806614716e1) *
+      r +
+      2.506628277459239) *
+      q) /
+    (((((-5.447609879822406e1 * r + 1.615858368580409e2) * r + -1.556989798598866e2) * r +
+      6.680131188771972e1) *
+      r +
+      -1.328068155288572e1) *
+      r +
+      1)
+  );
+}
+
 /**
- * Refit scores for every record in the matchup history with a Bradley-Terry
- * model, via the minorization-maximization algorithm (Hunter 2004). Unlike
- * incremental Elo, each result propagates through the whole comparison graph:
- * beating a record also strengthens the case against everything that record
- * has beaten. Strengths map onto the Elo scale used by expectedScore
- * (strength ratio 10 = 400 points), anchored so unplayed strength is 1200.
+ * Map raw relevance values onto the Elo scale by percentile rank through the
+ * inverse normal CDF, centered on the 1200 default, so priors follow the
+ * bell-shaped distribution matchup play converges to. Ties share the average
+ * rank, and the median relevance lands on 1200.
  */
-export function fitBradleyTerry(matchups: readonly MatchupOutcome[]): Map<number, number> {
+export function relevanceToEloPriors(relevances: ReadonlyMap<number, number>): Map<number, number> {
+  const tiers = [...Map.groupBy(relevances, ([, relevance]) => relevance)].sort(
+    ([a], [b]) => a - b
+  );
+  const priors = new Map<number, number>();
+  let rank = 0;
+  for (const [, tied] of tiers) {
+    const percentile = (rank + tied.length / 2) / relevances.size;
+    const elo = Math.round(DEFAULT_ELO + PRIOR_SD * probit(percentile));
+    for (const [id] of tied) priors.set(id, elo);
+    rank += tied.length;
+  }
+  return priors;
+}
+
+/**
+ * Refit scores for every record in the matchup history or the priors map with
+ * a Bradley-Terry model, via the minorization-maximization algorithm (Hunter
+ * 2004). Unlike incremental Elo, each result propagates through the whole
+ * comparison graph: beating a record also strengthens the case against
+ * everything that record has beaten. Each record anchors at its prior score
+ * (1200 when absent), so matchup evidence moves records relative to their
+ * priors and a record with no matchups scores exactly its prior. Strengths
+ * map onto the Elo scale used by expectedScore (strength ratio 10 = 400
+ * points).
+ */
+export function fitBradleyTerry(
+  matchups: readonly MatchupOutcome[],
+  priors: ReadonlyMap<number, number> = new Map()
+): Map<number, number> {
   const wins = new Map<number, number>();
   const games = new Map<number, Map<number, number>>();
   const addGame = (id: number, opponentId: number, won: number) => {
@@ -159,12 +232,17 @@ export function fitBradleyTerry(matchups: readonly MatchupOutcome[]): Map<number
     addGame(recordAId, recordBId, winA);
     addGame(recordBId, recordAId, 1 - winA);
   }
-  const strengths = new Map([...games.keys()].map((id): [number, number] => [id, 1]));
+  const anchors = new Map<number, number>();
+  for (const id of [...games.keys(), ...priors.keys()]) {
+    anchors.set(id, toStrength(priors.get(id) ?? DEFAULT_ELO));
+  }
+  const strengths = new Map(anchors);
   for (let iteration = 0; iteration < REFIT_MAX_ITERATIONS; iteration++) {
     let maxChange = 0;
     for (const [id, opponents] of games) {
-      const strength = strengths.get(id) ?? 1;
-      let denominator = REFIT_ANCHOR_GAMES / (strength + 1);
+      const anchor = anchors.get(id) ?? 1;
+      const strength = strengths.get(id) ?? anchor;
+      let denominator = REFIT_ANCHOR_GAMES / (strength + anchor);
       for (const [opponentId, count] of opponents) {
         denominator += count / (strength + (strengths.get(opponentId) ?? 1));
       }
@@ -175,6 +253,9 @@ export function fitBradleyTerry(matchups: readonly MatchupOutcome[]): Map<number
     if (maxChange < REFIT_TOLERANCE) break;
   }
   return new Map(
-    [...strengths].map(([id, strength]) => [id, Math.round(1200 + 400 * Math.log10(strength))])
+    [...strengths].map(([id, strength]) => [
+      id,
+      Math.round(DEFAULT_ELO + ELO_SCALE * Math.log10(strength)),
+    ])
   );
 }

--- a/src/shared/lib/elo.ts
+++ b/src/shared/lib/elo.ts
@@ -124,3 +124,57 @@ export function eloDeltas(
   const deltaB = Math.round(kFactor(b.matchupCount) * (1 - actualA - (1 - expectedA)));
   return { deltaA, deltaB };
 }
+
+/** A stored matchup outcome; a null winner is a draw. */
+export type MatchupOutcome = { recordAId: number; recordBId: number; winnerId: number | null };
+
+/**
+ * Pseudo-draws each record plays against a fixed 1200-rated anchor. They keep
+ * undefeated records finite, shrink sparse histories toward the default score,
+ * and pin disconnected regions of the comparison graph to a common scale.
+ */
+const REFIT_ANCHOR_GAMES = 2;
+const REFIT_MAX_ITERATIONS = 1000;
+const REFIT_TOLERANCE = 1e-10;
+
+/**
+ * Refit scores for every record in the matchup history with a Bradley-Terry
+ * model, via the minorization-maximization algorithm (Hunter 2004). Unlike
+ * incremental Elo, each result propagates through the whole comparison graph:
+ * beating a record also strengthens the case against everything that record
+ * has beaten. Strengths map onto the Elo scale used by expectedScore
+ * (strength ratio 10 = 400 points), anchored so unplayed strength is 1200.
+ */
+export function fitBradleyTerry(matchups: readonly MatchupOutcome[]): Map<number, number> {
+  const wins = new Map<number, number>();
+  const games = new Map<number, Map<number, number>>();
+  const addGame = (id: number, opponentId: number, won: number) => {
+    wins.set(id, (wins.get(id) ?? 0) + won);
+    const opponents = games.get(id) ?? new Map<number, number>();
+    opponents.set(opponentId, (opponents.get(opponentId) ?? 0) + 1);
+    games.set(id, opponents);
+  };
+  for (const { recordAId, recordBId, winnerId } of matchups) {
+    const winA = winnerId === null ? 0.5 : winnerId === recordAId ? 1 : 0;
+    addGame(recordAId, recordBId, winA);
+    addGame(recordBId, recordAId, 1 - winA);
+  }
+  const strengths = new Map([...games.keys()].map((id): [number, number] => [id, 1]));
+  for (let iteration = 0; iteration < REFIT_MAX_ITERATIONS; iteration++) {
+    let maxChange = 0;
+    for (const [id, opponents] of games) {
+      const strength = strengths.get(id) ?? 1;
+      let denominator = REFIT_ANCHOR_GAMES / (strength + 1);
+      for (const [opponentId, count] of opponents) {
+        denominator += count / (strength + (strengths.get(opponentId) ?? 1));
+      }
+      const next = ((wins.get(id) ?? 0) + REFIT_ANCHOR_GAMES / 2) / denominator;
+      maxChange = Math.max(maxChange, Math.abs(next - strength) / strength);
+      strengths.set(id, next);
+    }
+    if (maxChange < REFIT_TOLERANCE) break;
+  }
+  return new Map(
+    [...strengths].map(([id, strength]) => [id, Math.round(1200 + 400 * Math.log10(strength))])
+  );
+}


### PR DESCRIPTION
Arena matchups update ELO incrementally, so a result only ever moves its two participants. Beating a record says nothing about the records it has already beaten, and early matchups played at provisional K-factors never get revisited once the evidence around them grows. The stored matchup history carries all of that information, but nothing reads it back. Meanwhile records that have never entered the arena sit wherever the one-off seed script left them, on a scale nothing maintains.

Adds a batch refit that recomputes every record's score as prior plus evidence. Each record gets a prior derived from its current richness signals (links, media, notes, summary, content, curation — the seed script's formula, minus the retired star rating), percentile-mapped per record type onto a normal distribution centered on 1200. A Bradley-Terry model (Hunter's minorization-maximization fit) then moves records relative to their priors using the full matchup history, so each result propagates through the whole comparison graph and beating a proven winner counts for more. Strengths map back onto the existing Elo scale, so `expectedScore` keeps working unchanged.

- `fitBradleyTerry` and `relevanceToEloPriors` in `src/shared/lib/elo.ts`, with tests covering draws, transitive chains, propagation, prior anchoring, and the percentile mapping. Each record plays two pseudo-draws against an anchor at its own prior, which weights the prior against evidence (a record with no matchups scores exactly its prior), keeps undefeated records finite, and puts disconnected regions of the graph on one scale.
- `runEloRefit` service, which derives priors, fits, and writes only changed scores in batched statements. Exposed as the `records.refitElo` tRPC mutation and `rcr records refit-elo`.
- `elo` joins the enrichment pipeline (`rcr enrich`, after embeddings), so every sync re-derives priors from current richness and re-fits from the latest matchup history. Steady-state runs take well under a second; only the first run rewrites the full table.

Incremental arena updates stay the live layer; the refit periodically folds that drift back into prior + evidence. Since priors are recomputed from live signals on every run, scores need no seeding step for new records and track richness as links and media accrue.