### PR TITLE
Rank title matches above embedding similarity in the duplicates panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aias/red-cliff-record",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "license": "MIT",
   "author": {
     "name": "Nick Trombley",

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -14,9 +14,11 @@ import {
   ftsRank,
   lexicalMatchCondition,
   normalizedUrlColumn,
+  normalizeTitle,
   normalizeUrl,
   setTrigramThresholds,
   SIMILARITY_THRESHOLD,
+  titleMatchTier,
   trigramDistance,
   URL_DUPLICATE_CANDIDATE_LIMIT,
 } from '@/server/lib/constants';
@@ -85,15 +87,15 @@ export const searchRouter = createTRPCRouter({
         await setTrigramThresholds(tx);
         return tx.query.records.findMany({
           where: {
-            RAW: (records) => lexicalMatchCondition(records, query),
+            RAW: (t) => lexicalMatchCondition(t, query),
             type: recordType,
           },
           limit,
-          orderBy: (records, { desc }) => [
-            exactMatchTier(records, query),
-            desc(ftsRank(records.textSearch, query)),
-            trigramDistance(records, query),
-            desc(records.recordUpdatedAt),
+          orderBy: (t, { desc }) => [
+            exactMatchTier(t, query),
+            desc(ftsRank(t.textSearch, query)),
+            trigramDistance(t, query),
+            desc(t.recordUpdatedAt),
           ],
           columns: {
             id: true,
@@ -200,6 +202,7 @@ export const searchRouter = createTRPCRouter({
           columns: {
             id: true,
             textEmbedding: true,
+            title: true,
             url: true,
           },
           where: {
@@ -221,7 +224,7 @@ export const searchRouter = createTRPCRouter({
         if (!recordWithLinks) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' });
         }
-        const { textEmbedding, url, outgoingLinks, incomingLinks } = recordWithLinks;
+        const { textEmbedding, title, url, outgoingLinks, incomingLinks } = recordWithLinks;
 
         const omittedIds = [
           id,
@@ -253,8 +256,30 @@ export const searchRouter = createTRPCRouter({
             ? urlMatches.map((r) => r.id)
             : [];
 
+        // A shared or near-identical title is likewise a duplicate signal that
+        // outranks cosine similarity: sparse records embed mostly as their
+        // template, so the vector space cannot be trusted to put an identically
+        // titled record above a merely similar-shaped one.
+        const seedTitle = normalizeTitle(title);
+
         if (textEmbedding === null) {
-          return urlCandidateIds.map((candidateId) => ({
+          const titleMatches = seedTitle
+            ? await db.query.records.findMany({
+                columns: { id: true },
+                where: {
+                  AND: [
+                    { id: { notIn: omittedIds } },
+                    { isPrivate: false },
+                    type ? { type } : {},
+                    { RAW: (t) => sql`${titleMatchTier(t.title, seedTitle)} > 0` },
+                  ],
+                },
+                orderBy: (t, { desc }) => [desc(titleMatchTier(t.title, seedTitle))],
+                limit,
+              })
+            : [];
+          const candidateIds = [...new Set([...urlCandidateIds, ...titleMatches.map((r) => r.id)])];
+          return candidateIds.map((candidateId) => ({
             id: candidateId,
             similarity: null,
           }));
@@ -276,6 +301,7 @@ export const searchRouter = createTRPCRouter({
               {
                 OR: [
                   ...(urlCandidateIds.length > 0 ? [{ id: { in: urlCandidateIds } }] : []),
+                  { RAW: (t) => sql`${titleMatchTier(t.title, seedTitle)} > 0` },
                   {
                     AND: [
                       { textEmbedding: { isNotNull: true } },
@@ -309,6 +335,7 @@ export const searchRouter = createTRPCRouter({
           },
           orderBy: (t, { desc }) => [
             ...(urlCandidateIds.length > 0 ? [desc(inArray(t.id, urlCandidateIds))] : []),
+            desc(titleMatchTier(t.title, seedTitle)),
             sql`similarity DESC NULLS LAST`,
             desc(t.recordUpdatedAt),
           ],

--- a/src/server/lib/constants.ts
+++ b/src/server/lib/constants.ts
@@ -3,6 +3,9 @@ import { sql, type Column, type SQL } from 'drizzle-orm';
 export const SIMILARITY_THRESHOLD = 0.8; // Cosine similarity floor (higher = stricter)
 /** Max same-URL records pinned as duplicate candidates; larger clusters are junk (platform root URLs), not identity signals. */
 export const URL_DUPLICATE_CANDIDATE_LIMIT = 2;
+/** pg_trgm similarity floor for treating two titles as the same title spelled differently.
+ * Above it sit variants of one name; below it sit records that merely share a common word. */
+export const TITLE_VARIANT_SIMILARITY = 0.6;
 export const TRIGRAM_DISTANCE_THRESHOLD = 0.75; // pg_trgm distance ceiling (lower = stricter)
 export const WORD_SIMILARITY_THRESHOLD = 0.5; // pg_trgm word_similarity floor for phrase matching
 export const WORD_SIMILARITY_DISTANCE_THRESHOLD = 1 - WORD_SIMILARITY_THRESHOLD;
@@ -47,6 +50,36 @@ export const normalizeUrl = (url: string | null | undefined): string | null => {
 /** The same URL normalization as `normalizeUrl`, applied to a column. */
 export const normalizedUrlColumn = (column: Column): SQL =>
   sql`lower(regexp_replace(${column}, '^https?://(www\\.)?|/+$', '', 'g'))`;
+
+/** Strip case and collapse whitespace so titles compare by identity. */
+export const normalizeTitle = (title: string | null | undefined): string | null => {
+  if (!title) {
+    return null;
+  }
+  const normalized = title.toLowerCase().replace(/\s+/g, ' ').trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+/** The same title normalization as `normalizeTitle`, applied to a column. */
+export const normalizedTitleColumn = (column: Column): SQL =>
+  sql`btrim(lower(regexp_replace(${column}, '\\s+', ' ', 'g')))`;
+
+/**
+ * Tiered agreement with a seed title: 2 = the same title, 1 = a spelling
+ * variant, 0 = unrelated (every record, when the seed has no title). Two
+ * records sharing a title is a far stronger duplicate signal than the cosine
+ * distance between them, because sparse records embed mostly as their
+ * template — a bare name under a heading — and so sit closer to every other
+ * sparse record than to a fully populated record describing the same subject.
+ */
+export const titleMatchTier = (column: Column, normalizedTitle: string | null): SQL<number> =>
+  normalizedTitle === null
+    ? sql<number>`(0)`
+    : sql<number>`CASE
+        WHEN ${normalizedTitleColumn(column)} = ${normalizedTitle} THEN 2
+        WHEN similarity(${column}, ${normalizedTitle}) >= ${TITLE_VARIANT_SIMILARITY} THEN 1
+        ELSE 0
+      END`;
 
 /** Queries containing a dot or slash may be URLs or domains; only those should match against the url column. */
 const asUrlQuery = (query: string): string | null =>

--- a/src/shared/lib/embedding.ts
+++ b/src/shared/lib/embedding.ts
@@ -85,6 +85,13 @@ const joinList = (items: string[], threshold = 4): string => {
  * deliberately excluded: they describe where a record came from rather than
  * what it says, and including them clusters records by platform (e.g., all
  * tweets near all tweets) instead of by meaning.
+ *
+ * Relation lines lead with the record's own title rather than a bare label
+ * for the same reason: in a sparse record the label is most of the document,
+ * so two unrelated entities that both read "Creator of: …" embed closer to
+ * each other than to a fully populated record about the same subject.
+ * Repeating the title keeps identity tokens, not shared scaffolding,
+ * dominant in the vector.
  */
 export const createRecordEmbeddingText = (record: EmbeddingRecord) => {
   const { title, content, summary, notes, mediaCaption, outgoingLinks, incomingLinks, media } =
@@ -118,6 +125,9 @@ export const createRecordEmbeddingText = (record: EmbeddingRecord) => {
 
   const parts: string[] = [];
 
+  const relationLine = (subjectPhrase: string, barePhrase: string, titles: string[]) =>
+    title ? `${title} ${subjectPhrase}: ${joinList(titles)}` : `${barePhrase}: ${joinList(titles)}`;
+
   // === PRIMARY CONTENT (highest semantic value) ===
 
   // Title with context
@@ -132,7 +142,13 @@ export const createRecordEmbeddingText = (record: EmbeddingRecord) => {
 
   // Parent context (where this content comes from)
   if (parents.length > 0) {
-    parts.push(`From: ${parents.map((p) => getRecordTitle(p)).join(', ')}`);
+    parts.push(
+      relationLine(
+        'is from',
+        'From',
+        parents.map((p) => getRecordTitle(p))
+      )
+    );
   }
 
   // Core content
@@ -155,7 +171,7 @@ export const createRecordEmbeddingText = (record: EmbeddingRecord) => {
   // Child content (excerpts, highlights, etc.)
   if (children.length > 0) {
     const childTitles = children.map((c) => getRecordTitle(c, 500));
-    parts.push(`Contains: ${joinList(childTitles)}`);
+    parts.push(relationLine('contains', 'Contains', childTitles));
   }
 
   // Notes (user annotations)
@@ -167,23 +183,23 @@ export const createRecordEmbeddingText = (record: EmbeddingRecord) => {
 
   if (references.length > 0) {
     const refTitles = references.map((r) => getRecordTitle(r));
-    parts.push(`References: ${joinList(refTitles)}`);
+    parts.push(relationLine('references', 'References', refTitles));
   }
   if (referencedBy.length > 0) {
     const refByTitles = referencedBy.map((r) => getRecordTitle(r));
-    parts.push(`Referenced by: ${joinList(refByTitles)}`);
+    parts.push(relationLine('is referenced by', 'Referenced by', refByTitles));
   }
   if (associations.length > 0) {
     const assocTitles = associations.map((a) => getRecordTitle(a));
-    parts.push(`Related: ${joinList(assocTitles)}`);
+    parts.push(relationLine('is related to', 'Related', assocTitles));
   }
   if (tags.length > 0) {
     const tagTitles = tags.map((t) => getRecordTitle(t));
-    parts.push(`Tags: ${joinList(tagTitles)}`);
+    parts.push(relationLine('is tagged', 'Tags', tagTitles));
   }
   if (created.length > 0) {
     const createdTitles = created.map((c) => getRecordTitle(c));
-    parts.push(`Creator of: ${joinList(createdTitles)}`);
+    parts.push(relationLine('created', 'Creator of', createdTitles));
   }
 
   return parts.join('\n\n');


### PR DESCRIPTION
On a sparse record, the similar-records panel can rank an unrelated record above an identically titled one. Records with no body embed mostly as their shared template — a heading plus a relation label — so two bare entities that both read "Creator of: …" sit closer in vector space than a bare entity and the fully populated record describing the same person.

Addresses this on both fronts:

- `search.byRecordId` computes a per-candidate title tier (exact normalized match, trigram variant at `similarity ≥ 0.6`, unrelated) that sorts ahead of cosine similarity, unions title matches into the candidate set, and returns them even when the seed record has no embedding.
- Relation lines in embedding text lead with the record's own title (`Steve Ruiz created: …` rather than `Creator of: …`) so identity tokens, not shared scaffolding, dominate a sparse record's vector. Probed against the failing trio, this flips the margin between the true match and the confounder from +0.0005 to +0.031.

Stored embeddings predate the new format. After merging, null out `text_embedding`/`text_embedded_at` and run `rcr enrich embeddings` until drained; the title tier itself needs no regeneration and takes effect immediately.